### PR TITLE
Increase timeouts waiting for Service Worker

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2981,7 +2981,7 @@ function setContentInjectionMode (value) {
     settingsStore.setItem('contentInjectionMode', value, Infinity);
     setWindowOpenerUI();
     // Even in JQuery mode, the PWA needs to be able to serve the app in offline mode
-    setTimeout(initServiceWorkerMessaging, 1200);
+    setTimeout(initServiceWorkerMessaging, 2000);
 }
 
 /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2833,7 +2833,7 @@ function initServiceWorkerMessaging () {
         // If this is the first time we are initiating the SW, allow Promises to complete by delaying potential reload till next tick
         console.warn('The Service Worker needs more time to load, or else the app was force-refreshed...');
         serviceWorkerRegistration = null;
-        setTimeout(initServiceWorkerMessaging, 1800);
+        setTimeout(initServiceWorkerMessaging, 2000);
     } else if (params.contentInjectionMode === 'serviceworker') {
         console.error('The Service Worker is not controlling the current page! We have to reload.');
         // Turn off failsafe, as this is a controlled reboot
@@ -2981,7 +2981,7 @@ function setContentInjectionMode (value) {
     settingsStore.setItem('contentInjectionMode', value, Infinity);
     setWindowOpenerUI();
     // Even in JQuery mode, the PWA needs to be able to serve the app in offline mode
-    setTimeout(initServiceWorkerMessaging, 1000);
+    setTimeout(initServiceWorkerMessaging, 1200);
 }
 
 /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2981,7 +2981,7 @@ function setContentInjectionMode (value) {
     settingsStore.setItem('contentInjectionMode', value, Infinity);
     setWindowOpenerUI();
     // Even in JQuery mode, the PWA needs to be able to serve the app in offline mode
-    setTimeout(initServiceWorkerMessaging, 2500);
+    setTimeout(initServiceWorkerMessaging, 3000);
 }
 
 /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2981,7 +2981,7 @@ function setContentInjectionMode (value) {
     settingsStore.setItem('contentInjectionMode', value, Infinity);
     setWindowOpenerUI();
     // Even in JQuery mode, the PWA needs to be able to serve the app in offline mode
-    setTimeout(initServiceWorkerMessaging, 1500);
+    setTimeout(initServiceWorkerMessaging, 2500);
 }
 
 /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2833,7 +2833,7 @@ function initServiceWorkerMessaging () {
         // If this is the first time we are initiating the SW, allow Promises to complete by delaying potential reload till next tick
         console.warn('The Service Worker needs more time to load, or else the app was force-refreshed...');
         serviceWorkerRegistration = null;
-        setTimeout(initServiceWorkerMessaging, 2000);
+        setTimeout(initServiceWorkerMessaging, 3000);
     } else if (params.contentInjectionMode === 'serviceworker') {
         console.error('The Service Worker is not controlling the current page! We have to reload.');
         // Turn off failsafe, as this is a controlled reboot
@@ -2981,7 +2981,7 @@ function setContentInjectionMode (value) {
     settingsStore.setItem('contentInjectionMode', value, Infinity);
     setWindowOpenerUI();
     // Even in JQuery mode, the PWA needs to be able to serve the app in offline mode
-    setTimeout(initServiceWorkerMessaging, 2000);
+    setTimeout(initServiceWorkerMessaging, 1500);
 }
 
 /**


### PR DESCRIPTION
With the addition of replayWorker, which is quite heavy to cache, the Service Worker may not have fully loaded before the app decides it has to issue a refresh (an essential workaround for stuck Service Workers). Because a refresh dismisses the initial welcome dialogue, this can be problematic for first install.