### PR TITLE
Fix untransformed relative zimit2 URLs without wombat

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5217,6 +5217,10 @@ function handleClickOnReplayLink (ev, anchor) {
     // If it starts with the path to the ZIM file, then we are dealing with an untransformed absolute local ZIM link
     if (!anchor.href.indexOf(pathToZim)) {
         zimUrl = anchor.href.replace(pathToZim, '');
+    // If it is the same as the pseudoDomainPath, then we are dealing with an untransformed pseuodo relative link that looks like an absolute https:// link
+    // (this probably only applies to zimit2 without Wombat)
+    } else if (anchor.href.replace(/^[^:]+:\/\//, '') === pseudoDomainPath && /\.zim\/[CA]\//.test(anchor.href)) {
+        zimUrl = anchor.href.replace(/^(?:[^.]|\.(?!zim\/[CA]\/))+\.zim\//, '');
     } else {
         zimUrl = pseudoNamespace + pseudoDomainPath + anchor.search;
     }


### PR DESCRIPTION
In some zimit2 ZIM archives without Wombat (because it is unsupported with the browser version), we get some absolute URLs that are actually ZIM URLs with the pseudo-domain added in front. In such contexts, we need to deal with this when clicking on such a link.