### PR TITLE
Workaround for HTML URLs with percent-encoded querystring separators in zimit2

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5231,6 +5231,9 @@ function handleClickOnReplayLink (ev, anchor) {
     } else {
         zimUrl = pseudoNamespace + pseudoDomainPath + anchor.search;
     }
+    if (params.zimType === 'zimit2') {
+        zimUrl = decodeURIComponent(zimUrl);
+    }
     // We need to test the ZIM link
     if (zimUrl) {
         ev.preventDefault();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5231,10 +5231,10 @@ function handleClickOnReplayLink (ev, anchor) {
     } else {
         zimUrl = pseudoNamespace + pseudoDomainPath + anchor.search;
     }
-    // It may be necessary to fully decode zimit2 pending discussions
-    // if (params.zimType === 'zimit2') {
-    //     zimUrl = decodeURIComponent(zimUrl);
-    // }
+    // It is necessary to fully decode zimit2, as these archives follow OpenZIM spec
+    if (params.zimType === 'zimit2') {
+        zimUrl = decodeURIComponent(zimUrl);
+    }
     // We need to test the ZIM link
     if (zimUrl) {
         ev.preventDefault();
@@ -5439,8 +5439,8 @@ function handleMessageChannelMessage (event) {
         // Zimit ZIMs store assets with the querystring, so we need to add it!
         title = title + event.data.search;
     } else {
-        // Zimit archives store URLs encoded, and also need the URI component (search parameter) if any
-        if (/zimit/.test(params.zimType)) {
+        // Zimit1 (classic) archives store URLs encoded, and also need the URI component (search parameter) if any
+        if (params.zimType === 'zimit') {
             title = encodeURI(event.data.title) + event.data.search;
         }
         // If it's an asset, we have to mark the dirEntry so that we don't load it if it has an html MIME type

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5231,9 +5231,10 @@ function handleClickOnReplayLink (ev, anchor) {
     } else {
         zimUrl = pseudoNamespace + pseudoDomainPath + anchor.search;
     }
-    if (params.zimType === 'zimit2') {
-        zimUrl = decodeURIComponent(zimUrl);
-    }
+    // It may be necessary to fully decode zimit2 pending discussions
+    // if (params.zimType === 'zimit2') {
+    //     zimUrl = decodeURIComponent(zimUrl);
+    // }
     // We need to test the ZIM link
     if (zimUrl) {
         ev.preventDefault();
@@ -5439,7 +5440,7 @@ function handleMessageChannelMessage (event) {
         title = title + event.data.search;
     } else {
         // Zimit archives store URLs encoded, and also need the URI component (search parameter) if any
-        if (params.zimType === 'zimit') {
+        if (/zimit/.test(params.zimType)) {
             title = encodeURI(event.data.title) + event.data.search;
         }
         // If it's an asset, we have to mark the dirEntry so that we don't load it if it has an html MIME type


### PR DESCRIPTION
We need to fix clicking on a link which has querystring separators like `?` and `=` encoded. We find these in zimit2 at least because they have been introduced as a workaround for the fact the Kiwix Serve can't handle querystrings. See https://github.com/openzim/libzim/issues/865 for details.