### PR TITLE
Fix failure to print HTML books in Gutenberg ZIMs

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -463,10 +463,12 @@ function printIntercept () {
     if (!innerDoc) {
         return uiUtil.systemAlert('Sorry, we could not find a document to print! Please load one first.', 'Warning');
     }
-    // Re-establishe lastPageVisit because it is not always set, for example with dynamic loads
-    params.lastPageVisit = articleDocument.location.href.replace(/^.+\/([^/]+\.[zZ][iI][mM]\w?\w?)\/([CA]\/.*$)/, function (m0, zimName, zimURL) {
-        return decodeURI(zimURL) + '@kiwixKey@' + decodeURI(zimName);
-    });
+    if (params.contentInjectionMode === 'serviceworker') {
+        // Re-establishe lastPageVisit because it is not always set, for example with dynamic loads, in SW mode
+        params.lastPageVisit = articleDocument.location.href.replace(/^.+\/([^/]+\.[zZ][iI][mM]\w?\w?)\/([CA]\/.*$)/, function (m0, zimName, zimURL) {
+            return decodeURI(zimURL) + '@kiwixKey@' + decodeURI(zimName);
+        });
+    }
     var printDesktopCheck = document.getElementById('printDesktopCheck').checked;
     var printImageCheck = document.getElementById('printImageCheck').checked;
     var styleIsDesktop = !/href\s*=\s*["'][^"']*?(?:minerva|mobile)/i.test(innerDoc.head.innerHTML);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -463,11 +463,15 @@ function printIntercept () {
     if (!innerDoc) {
         return uiUtil.systemAlert('Sorry, we could not find a document to print! Please load one first.', 'Warning');
     }
+    // Re-establishe lastPageVisit because it is not always set, for example with dynamic loads
+    params.lastPageVisit = articleDocument.location.href.replace(/^.+\/([^/]+\.[zZ][iI][mM]\w?\w?)\/([CA]\/.*$)/, function (m0, zimName, zimURL) {
+        return decodeURI(zimURL) + '@kiwixKey@' + decodeURI(zimName);
+    });
     var printDesktopCheck = document.getElementById('printDesktopCheck').checked;
     var printImageCheck = document.getElementById('printImageCheck').checked;
     var styleIsDesktop = !/href\s*=\s*["'][^"']*?(?:minerva|mobile)/i.test(innerDoc.head.innerHTML);
     // if (styleIsDesktop != printDesktopCheck || printImageCheck && !params.allowHTMLExtraction || params.contentInjectionMode == 'serviceworker') {
-    if (!appstate.isReplayWorkerAvailable && (styleIsDesktop !== printDesktopCheck || (printImageCheck && !params.allowHTMLExtraction))) {
+    if (appstate.wikimediaZimLoaded && (styleIsDesktop !== printDesktopCheck || (printImageCheck && !params.allowHTMLExtraction))) {
         // We need to reload the document because it doesn't match the requested style or images are one-time BLOBs
         params.cssSource = printDesktopCheck ? 'desktop' : 'mobile';
         params.rememberLastPage = true; // Re-enable caching to speed up reloading of page

--- a/www/js/lib/images.js
+++ b/www/js/lib/images.js
@@ -386,7 +386,7 @@ function prepareImagesJQuery (win, forPrinting) {
         }
     }
 
-    if (forPrinting) {
+    if (forPrinting || params.imageDisplayMode === 'all') {
         extractImages(documentImages, params.preloadingAllImages ? params.preloadAllImages : params.printImagesLoaded);
     } else if (params.imageDisplayMode === 'progressive') {
         // We need to start detecting images after the hidden articleContent has been displayed (otherwise they are not detected)

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -451,10 +451,20 @@ function printCustomElements (innerDocument) {
         printStyleInnerHTML += '.map-pin { display: none } ';
         printStyleInnerHTML += '.external { padding-right: 0 !important } ';
     }
+    if (/gutenberg/i.test(appstate.selectedArchive.file.name)) {
+        // Remove any blocks with classnames zim_info, zim_epub and zim_up
+        var elementsToRemove = innerDocument.body.querySelectorAll('.zim_info, .zim_epub, .zim_up');
+        if (elementsToRemove) {
+            for (var i = 0; i < elementsToRemove.length; i++) {
+                elementsToRemove[i].parentNode.removeChild(elementsToRemove[i]);
+            }
+            params.printInterception = true;
+        }
+    }
     // Using @media print on images doesn't get rid of them all, so use brute force
     if (!document.getElementById('printImageCheck').checked) {
         innerDocument.body.innerHTML = innerDocument.body.innerHTML.replace(/<img\b[^>]*>\s*/ig, '');
-    } else if (appstate.selectedArchive.zimType === 'open') {
+    } else if (/id="breakoutLink"/.test(innerDocument.body.innerHTML)) {
         // Remove any breakout link
         innerDocument.body.innerHTML = innerDocument.body.innerHTML.replace(/<img\b[^>]+id="breakoutLink"[^>]*>\s*/, '');
     }


### PR DESCRIPTION
Fixes #579.

So far, it can now print the HTML in the iframe, but images are not being retrieved.

Also fixes the bug with mobile vs desktop printing.