### PR TITLE
With FSA persistent permissions go straight to article view

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1119,7 +1119,7 @@ function getNativeFSHandle (callback) {
                     if (callback) {
                         callback(handle);
                     } else {
-                        searchForArchivesInPreferencesOrStorage(true);
+                        searchForArchivesInPreferencesOrStorage();
                     }
                 }
             });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3235,6 +3235,8 @@ if (storages !== null && storages.length > 0 ||
         if (params.useOPFS) {
             if (!params.storedFile) btnConfigure.click();
             loadOPFSDirectory();
+        } else if (params.storedFile && navigator && navigator.storage && 'getDirectory' in navigator.storage) {
+            getNativeFSHandle();
         } else {
             // We are in an app that cannot open files auotomatically, so populate archive list and show file pickers
             btnConfigure.click();


### PR DESCRIPTION
Fixes #573. Need to check for regressions when FSA permissions not granted.