### PR TITLE
Fix failure to display URLs ending in question mark

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6722,7 +6722,9 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
             transDirEntry = dirEntry;
             // We will need the encoded URL on article load so that we can set the iframe's src correctly,
             // but we must not encode the '/' character or else relative links may fail [kiwix-js #498]
-            var encodedUrl = /zimit/.test(params.zimType) ? dirEntry.url : encodeURI(dirEntry.url);
+            var encodedUrl = dirEntry.url.replace(/[^/]+/g, function (matchedSubstring) {
+                return encodeURIComponent(matchedSubstring);
+            });
             // If the request was not initiated by an existing controlled window, we instantiate the request here
             if (!messageChannelWaiting) {
                 // We put the ZIM filename as a prefix in the URL, so that browser caches are separate for each ZIM file


### PR DESCRIPTION
Fixes #654.

I discovered that Kiwix JS does not exhibit the problem described, and it turns out to be that using `encodeURI()`, unlike `encodeURIComponent()` does not encode question marks. The problem here is the need to encode a question mark when it is part of the dirEntry's url or title, as will always be the case in Wikipedia ZIMs. But in fact, because even Zimit does not have a concept of a querystring, even if a querystring is present in the URL, that we always need to encode the full dirEntry.url before placing it in the iframe's location.href field (or redirecting to it in separate tabs). So, we have to use `encodeURIComponent()` but taking care not to encode forward slashes! This is how Kiwix JS does it, by encoding the parts between forward slashes.

Hopefully this will work in all circumstances and ZIM types, but it does need careful testing.