### PR TITLE
Accept ZIM minor version 3

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -468,13 +468,13 @@ ZIMArchive.prototype.findDirEntriesWithPrefix = function (search, callback, noIn
 ZIMArchive.prototype.getContentNamespace = function () {
     if (this.isReady()) {
         var ver = this.file.minorVersion;
-        // DEV: There are currently only three defined values for minorVersion in the OpenZIM specification
+        // DEV: There are currently only four defined values for minorVersion in the OpenZIM specification
         // If this changes, adapt the error checking and return values
         switch (ver) {
         case 0:
             return 'A'; // Old-format ZIM files
-        case 1: // ZIM with new namespaces, with all user content under 'C'
-        case 2: // ZIM explicitly allowing alias entries       
+        case 1: // ZIM with new namespaces, all user content under 'C'
+        case 2: // ZIM explicitly allowing alias entries
         case 3: // ZIMs without a v0 title index (no 'listing/titleOrdered/v0')
             return 'C'; // New-format ZIM files
         default:

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -470,8 +470,8 @@ ZIMArchive.prototype.getContentNamespace = function () {
         var ver = this.file.minorVersion;
         // DEV: There are currently only two defined values for minorVersion in the OpenZIM specification
         // If this changes, adapt the error checking and return values
-        if (ver > 2) {
-            console.error('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
+        if (ver > 3) {
+            console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
         }
         return ver === 0 ? 'A' : 'C';
     } else {

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -470,10 +470,16 @@ ZIMArchive.prototype.getContentNamespace = function () {
         var ver = this.file.minorVersion;
         // DEV: There are currently only two defined values for minorVersion in the OpenZIM specification
         // If this changes, adapt the error checking and return values
-        if (ver > 3) {
-            console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
+        switch (ver) {
+            case 0:
+                return 'A'; // Old-format ZIM files
+            case 1:
+            case 3: // Explicitly handle version 3 as equivalent to version 1
+                return 'C'; // New-format ZIM files
+            default:
+                console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
+                return 'C'; // Default assumption for unknown versions
         }
-        return ver === 0 ? 'A' : 'C';
     } else {
         throw new Error('We could not determine the content namespace because the ZIM file is not ready!');
     }

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * zimArchive.js: Support for archives in ZIM format.
  *
  * Copyright 2015-2023 Mossroy, Jaifroid and contributors
@@ -473,8 +473,9 @@ ZIMArchive.prototype.getContentNamespace = function () {
         switch (ver) {
         case 0:
             return 'A'; // Old-format ZIM files
-        case 1:
-        case 3: // Explicitly handle version 3 as equivalent to version 1
+        case 1: // ZIM with new namespaces, with all user content under 'C'
+        case 2: // ZIM explicitly allowing alias entries       
+        case 3: // ZIMs without a v0 title index (no 'listing/titleOrdered/v0')
             return 'C'; // New-format ZIM files
         default:
             console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -471,14 +471,14 @@ ZIMArchive.prototype.getContentNamespace = function () {
         // DEV: There are currently only three defined values for minorVersion in the OpenZIM specification
         // If this changes, adapt the error checking and return values
         switch (ver) {
-            case 0:
-                return 'A'; // Old-format ZIM files
-            case 1:
-            case 3: // Explicitly handle version 3 as equivalent to version 1
-                return 'C'; // New-format ZIM files
-            default:
-                console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
-                return 'C'; // Default assumption for unknown versions
+        case 0:
+            return 'A'; // Old-format ZIM files
+        case 1:
+        case 3: // Explicitly handle version 3 as equivalent to version 1
+            return 'C'; // New-format ZIM files
+        default:
+            console.warn('Unknown ZIM minor version: ' + ver + '! Assuming content namespace is C.');
+            return 'C'; // Default assumption for unknown versions
         }
     } else {
         throw new Error('We could not determine the content namespace because the ZIM file is not ready!');

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -468,7 +468,7 @@ ZIMArchive.prototype.findDirEntriesWithPrefix = function (search, callback, noIn
 ZIMArchive.prototype.getContentNamespace = function () {
     if (this.isReady()) {
         var ver = this.file.minorVersion;
-        // DEV: There are currently only two defined values for minorVersion in the OpenZIM specification
+        // DEV: There are currently only three defined values for minorVersion in the OpenZIM specification
         // If this changes, adapt the error checking and return values
         switch (ver) {
             case 0:

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -474,7 +474,9 @@ ZIMArchive.prototype.getContentNamespace = function () {
         case 0:
             return 'A'; // Old-format ZIM files
         case 1: // ZIM with new namespaces, all user content under 'C'
+            // fall-through
         case 2: // ZIM explicitly allowing alias entries
+            // fall-through
         case 3: // ZIMs without a v0 title index (no 'listing/titleOrdered/v0')
             return 'C'; // New-format ZIM files
         default:


### PR DESCRIPTION
This PR fixes failure to detect the new ZIM minor version 3 that has no v0 title index (see https://github.com/openzim/libzim/issues/800 for full details).