### PR TITLE
Fix runaway regular expression when parsing MathML

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6443,8 +6443,8 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
 
     // Replace all TeX SVGs with MathJax scripts
     if (params.useMathJax) {
-        // Deal with any newer MathML blocks
-        htmlArticle = htmlArticle.replace(/(<math\b[^>]+alttext=(["']))((?:[^"']|[\s\S](?!\2))+?)(\2(?:[^<]|<(?!\/math))+(?:[^<]|<(?!img))+)<img\b[^>]+?class=["'][^"']*?mwe-math-fallback-image[^>]+>/ig,
+        // Deal with any newer MathML blocksº
+        htmlArticle = htmlArticle.replace(/(<math\b[^>]+alttext=(["']))((?:[^\s\S](?!\2))+)(\2(?:[^<]|<(?!\/math))+(?:[^<]|<(?!img))+)<img\b[^>]+?class=["'][^"']*?mwe-math-fallback-image[^>]+>/ig,
         function (_p0, p1, _p2, math, p4) {
             // Remove any rogue ampersands in MathJax due to double escaping (by Wikipedia)
             math = math.replace(/&amp;/g, '&');


### PR DESCRIPTION
Fixes #714 .

This occurs when MathML is enabled in ZIMs without images. The regex is looking for a fallback image and backtracks catastrophically through the whole html.