### PR TITLE
Fix typo in configuration page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1226,7 +1226,7 @@
                                 <label class="radio">
                                     <input type="radio" name="useMathJax" id="useMathJaxRadioFalse" value="false">
                                     <span class="radiobtn"></span>
-                                    <b>Use SVG fallback images</b> (slow and memory-hungry, but will dislplay all symbols)
+                                    <b>Use SVG fallback images</b> (slow and memory-hungry, but will display all symbols)
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
@Jaifroid This PR resolves a typo in the Configuration page regarding SVG fallback images

Corrected "dislplay" to 'display"