### PR TITLE
docs: add WebTorrent documentation for Electron application

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ When the app is running, the Home tab displays a localhost URL (by default `http
 - Access from other devices uses HTTP rather than HTTPS, so browsers will run the application in **Restricted mode** instead of **ServiceWorker Mode**. This is generally suitable for reading Wikipedia and other static ZIM archives, but some dynamic ZIMs may have limited functionality.
 - For your security, external network access is disabled by default, applies only to the current session, and accepts connections only from the local network.
 
+### BitTorrent downloads (Electron)
+
+The Electron edition of Kiwix JS PWA includes a built-in BitTorrent client for downloading large ZIM archives directly within the application. Downloads can be resumed if interrupted, including after restarting the application. Previously downloaded data is reused automatically.
+
+For more information about managing BitTorrent downloads, see the in-app About documentation.
+
 ## Technical information
 
 This repository is for development of the Kiwix JS app for PWA, Electron, NWJS and Windows 10/11 Universal Windows Platform (UWP).

--- a/www/index.html
+++ b/www/index.html
@@ -302,6 +302,7 @@
                         <li><a href="#windows">Window and tab management</a></li>
                         <li><a href="browsers">Browser support</a></li>
                         <li><a href="#expressServer">Express server (Electron app)</a></li>
+                        <li><a href="#webTorrent">BitTorrent downloads (Electron app)</a></li>
                         <li><a href="#modes">Technical Information</a></li>
                         <li><a href="#privacy">Privacy Policy</a></li>
                         <li><a href="#feedback">Feedback and Support</a></li>
@@ -717,6 +718,50 @@
                         <li>The server only allows connections from your local network (private IP ranges), not from the public internet</li>
                         <li>External access is disabled by default for security and only applies to the current session</li>
                     </ul>
+
+                    <h3 id="webTorrent">BitTorrent downloads (Electron app)</h3>
+
+                    <p>
+                        When running in the Electron framework, the app includes a built-in BitTorrent client for downloading large ZIM
+                        archives directly from the Download Library. BitTorrent downloads are recommended for large archives because interrupted downloads can be resumed, even after closing the application.
+                    </p>
+
+                    <p>
+                        <b>Downloading archives:</b>
+                    </p>
+
+                    <ol>
+                        <li>Open the Download Library and browse or search for the archive you want to download.</li>
+                        <li>If the archive supports BitTorrent, click <b>Download via BitTorrent</b>.</li>
+                        <li>Choose the default download folder or select another location if required, then start the download.</li>
+                        <li>Your Firewall may prompt you to allow network access the first time the BitTorrent client is used. Approve this
+                            to enable BitTorrent downloads.</li>
+                    </ol>
+
+                    <p>
+                        <b>Managing downloads:</b>
+                    </p>
+
+                    <ul>
+                        <li>While a download is in progress, selecting Download via BitTorrent again lets you either continue or stop the download.</li>
+                        <li>If you stop a download, the partially downloaded data is kept. Selecting <b>Download via BitTorrent</b> for the
+                            same archive again resumes the download from where it left off.</li>
+                        <li>If the application is closed while a download is in progress, you will be prompted to <b>Resume</b> or
+                            <b>Discard</b> the download when the application is restarted.</li>
+                        <li>Choosing <b>Resume</b> continues the download using the previously downloaded data.</li>
+                        <li>Choosing <b>Discard</b> deletes the saved partial download.</li>
+                    </ul>
+
+                    <p>
+                        <b>Important notes:</b>
+                    </p>
+
+                    <ul>
+                        <li>Completed downloads continue seeding to other BitTorrent users while the application is running.</li>
+                        <li>You can disable seeding in <b>Configuration &gt; Download library</b> by clearing the <b>Keep seeding BitTorrent
+                                downloads</b> option.</li>
+                    </ul>
+
                     <h3 id="modes">Technical information</h3>
                     <p>
                         Depending on your browser or framework, this app may be capable of running in two different modes, which we call

--- a/www/index.html
+++ b/www/index.html
@@ -736,6 +736,10 @@
                         <li>Choose the default download folder or select another location if required, then start the download.</li>
                         <li>Your Firewall may prompt you to allow network access the first time the BitTorrent client is used. Approve this
                             to enable BitTorrent downloads.</li>
+                            <li>
+                                If your version of Kiwix JS does not support WebTorrent, you can still download large archives using an
+                                external BitTorrent client by clicking on the provided torrent or magnet links.
+                            </li>
                     </ol>
 
                     <p>


### PR DESCRIPTION
## Summary

This PR adds documentation for the Electron app's built-in BitTorrent client.

Changes include:

- Added a new "BitTorrent downloads (Electron app)" section to the in-app About documentation.
- Added a brief README section describing BitTorrent downloads and linking users to the in-app documentation.
- Documented download management, resuming interrupted downloads, Resume/Discard behavior, and seeding.

Closes #903