### PR TITLE
Harden querystring parameter handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     ]
   },
   "scripts": {
+    "test": "node test/overrideParams.test.cjs",
     "serve": "vite",
     "preview": "del-cli dist && npm run build-src && vite preview",
     "prebuild": "del-cli dist",

--- a/test/overrideParams.test.cjs
+++ b/test/overrideParams.test.cjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Checks the querystring parameter handling in www/js/init.js.
+ *
+ * The app lets its own contexts pass settings to one another through the querystring (the UWP <-> PWA
+ * handoffs, and the reload in resetApp.js), and lets a developer drive any setting the same way. Which
+ * of those parameters may be written to the Settings Store, and which are accepted at all, is decided
+ * by four lists in overrideParams(). Those lists are easy to extend without noticing what the extension
+ * implies, so this file pins the intended behaviour of each one.
+ *
+ * init.js is a standalone script rather than a module - it is loaded with a plain <script src> and is
+ * not bundled, because it must run before anything else and cannot depend on the module graph. It
+ * therefore cannot be required. Instead we slice overrideParams() out of the source and evaluate it
+ * against stubs, so these checks always run the real code rather than a copy that can drift from it.
+ *
+ * Usage: npm test
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const INIT_JS = path.join(__dirname, '..', 'www', 'js', 'init.js');
+
+// ---------------------------------------------------------------------------------------------------
+// Extract the real overrideParams() from init.js
+// ---------------------------------------------------------------------------------------------------
+
+function extractOverrideParams (source) {
+    const start = source.indexOf('(function overrideParams ()');
+    const end = source.indexOf('\n})();', start);
+    if (start < 0 || end < 0) {
+        throw new Error('Could not locate overrideParams() in ' + INIT_JS + '. If it was renamed or ' +
+            'restructured, update the markers in this file - do not delete the checks.');
+    }
+    const extracted = source.slice(start, end + '\n})();'.length);
+    // Guard against silently testing a stale or partial slice: if any of these disappears, the checks
+    // below could pass while exercising something quite different from what they describe
+    ['persistableParams', 'neverFromQuerystring', 'devOnlyParams', 'validatedParams', 'forbiddenParams',
+        'trustedContext'].forEach(function (name) {
+        if (!extracted.includes(name)) {
+            throw new Error('The extracted overrideParams() no longer mentions "' + name + '". Either it ' +
+                'was renamed, or the extraction markers are catching the wrong part of the file.');
+        }
+    });
+    return extracted;
+}
+
+const overrideParamsSource = extractOverrideParams(fs.readFileSync(INIT_JS, 'utf8'));
+
+/**
+ * Runs the real overrideParams() against a stubbed environment
+ *
+ * @param {String} search The querystring, including its leading '?'
+ * @param {Object} context The app type and location to simulate
+ * @returns {Object} The resulting params object, and the settings that were written to the Store
+ */
+function run (search, context) {
+    const store = {};
+    const params = { appType: context.appType };
+    // These are the free variables the extracted code closes over in init.js. They are declared with var
+    // so that the evaluated source, which is strict-mode, resolves them from this scope.
+    var window = { location: { search: search, hostname: context.hostname, protocol: context.protocol } }; // eslint-disable-line no-unused-vars
+    var setSetting = function (name, val) { store[name] = val; }; // eslint-disable-line no-unused-vars
+    var console = { warn: function () {}, debug: function () {} }; // eslint-disable-line no-unused-vars
+    // eslint-disable-next-line no-eval
+    eval(overrideParamsSource);
+    return { params: params, store: store };
+}
+
+// The contexts the app actually runs in. Note that the Electron app serves itself from http://localhost
+// via its bundled Express server, and NW.js runs from file:, so neither can be told apart from a
+// developer's machine by origin alone.
+const PRODUCTION = { appType: 'HTML5|PWA|Windows', hostname: 'pwa.kiwix.org', protocol: 'https:' };
+const DEV_SERVER = { appType: 'HTML5|PWA|Windows', hostname: 'localhost', protocol: 'http:' };
+const SELF_HOSTED = { appType: 'HTML5|PWA|Linux', hostname: 'localhost', protocol: 'http:' };
+const ELECTRON = { appType: 'Electron|PWA|Windows', hostname: 'localhost', protocol: 'http:' };
+const UWP = { appType: 'UWP|PWA|Windows', hostname: '', protocol: 'ms-appx-web:' };
+const NWJS = { appType: 'Electron|PWA|Windows', hostname: '', protocol: 'file:' };
+
+// ---------------------------------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------------------------------
+
+let failures = 0;
+let total = 0;
+
+function section (title) {
+    console.log('\n' + title);
+}
+
+function check (description, passed) {
+    total++;
+    if (passed) {
+        console.log('  ok    ' + description);
+    } else {
+        failures++;
+        console.log('  FAIL  ' + description);
+    }
+}
+
+// NB always test for own properties: 'toString' in {} is true through the prototype chain, which would
+// make several of the checks below pass without testing anything
+function stored (result, key) {
+    return Object.prototype.hasOwnProperty.call(result.store, key);
+}
+
+let r;
+
+section('Parameters that are never accepted from the querystring');
+[['on the production origin', PRODUCTION], ['on a development origin', DEV_SERVER],
+    ['on a self-hosted origin', SELF_HOSTED], ['in the Electron app', ELECTRON], ['in the UWP app', UWP],
+    ['in NW.js, running from file:', NWJS]].forEach(function (pair) {
+    r = run('?sourceVerification=false', pair[1]);
+    check('sourceVerification is ignored ' + pair[0],
+        !stored(r, 'sourceVerification') && r.params.sourceVerification === undefined);
+});
+
+section('Parameters restricted to a development context');
+r = run('?noPrompts=true&PWAServer=https%3A%2F%2Fpwa.kiwix.org%2F', PRODUCTION);
+check('noPrompts is ignored on the production origin', r.params.noPrompts === undefined);
+check('PWAServer is ignored on the production origin, even with an allowed value',
+    r.params.PWAServer === undefined && !stored(r, 'PWAServer'));
+r = run('?noPrompts=true', ELECTRON);
+check('noPrompts is ignored in the Electron app, which also runs on localhost',
+    r.params.noPrompts === undefined);
+r = run('?noPrompts=true&PWAServer=https%3A%2F%2Fkiwix.github.io%2Fkiwix-js-pwa%2Fdist%2F', DEV_SERVER);
+check('noPrompts is honoured on a development origin', r.params.noPrompts === true);
+check('PWAServer is honoured on a development origin when it matches the allowlist',
+    r.params.PWAServer === 'https://kiwix.github.io/kiwix-js-pwa/dist/');
+r = run('?PWAServer=https%3A%2F%2Fexample.com%2F', DEV_SERVER);
+check('PWAServer is refused on a development origin when it does not match the allowlist',
+    r.params.PWAServer === undefined);
+
+section('Development server workflow');
+r = run('?appCache=false', DEV_SERVER);
+check('appCache is honoured and stored on the development server (vite opens the app with this)',
+    r.store.appCache === 'false' && r.params.appCache === false);
+
+section("Settings passed between the app's own contexts");
+r = run('?allowInternetAccess=true&packagedFile=wikimed.zim&fileVersion=2024-01&lastSelectedArchive=my.zim',
+    PRODUCTION);
+check('allowInternetAccess is stored', r.store.allowInternetAccess === 'true' && r.params.allowInternetAccess === true);
+check('packagedFile is stored', r.store.packagedFile === 'wikimed.zim');
+check('fileVersion is stored', r.store.fileVersion === '2024-01');
+check('lastSelectedArchive is stored under its own key', r.store.lastSelectedArchive === 'my.zim');
+check('lastSelectedArchive is aliased to params.storedFile', r.params.storedFile === 'my.zim');
+r = run('?contentInjectionMode=serviceworker&manipulateImages=false&allowHTMLExtraction=false', PRODUCTION);
+check('contentInjectionMode is stored', r.store.contentInjectionMode === 'serviceworker');
+check('manipulateImages is stored', r.store.manipulateImages === 'false' && r.params.manipulateImages === false);
+check('allowHTMLExtraction is stored', r.store.allowHTMLExtraction === 'false');
+r = run('?lastPageVisit=A%2FSome_page', PRODUCTION);
+check('lastPageVisit applies to the current page load', r.params.lastPageVisit === 'A/Some_page');
+check('lastPageVisit is not stored, as init.js never reads it back under that key',
+    !stored(r, 'lastPageVisit'));
+
+section('Endpoint parameters restricted to Kiwix hosts');
+[['kiwixDownloadServer', 'https://staging.download.kiwix.org/zim/'],
+    ['kiwixCatalogEntries', 'https://opds.library.kiwix.org/catalog/v2/entries?count=-1'],
+    ['kiwixMirrorServer', 'https://mirror.download.kiwix.org'],
+    ['kiwixLibraryBrowser', 'https://browse.library.kiwix.org']].forEach(function (pair) {
+    r = run('?' + pair[0] + '=' + encodeURIComponent(pair[1]), PRODUCTION);
+    check(pair[0] + ' accepts ' + pair[1], r.store[pair[0]] === pair[1]);
+});
+['https://example.com/zim/', 'https://kiwix.org.example.com/', 'https://notkiwix.org/',
+    'https://kiwix.github.io.example.com/', 'http://opds.library.kiwix.org/'].forEach(function (url) {
+    r = run('?kiwixDownloadServer=' + encodeURIComponent(url), PRODUCTION);
+    check('kiwixDownloadServer refuses ' + url,
+        !stored(r, 'kiwixDownloadServer') && r.params.kiwixDownloadServer === undefined);
+});
+
+section('Keys that could alter the params prototype');
+r = run('?toString=x', PRODUCTION);
+check('an inherited property name does not throw, and is not stored', !stored(r, 'toString'));
+r = run('?__proto__=x&constructor=y&prototype=z', PRODUCTION);
+check('__proto__, constructor and prototype are skipped',
+    !stored(r, '__proto__') && !stored(r, 'constructor') && !stored(r, 'prototype'));
+check('the params prototype is intact', Object.getPrototypeOf(r.params) === Object.prototype);
+
+section('Unlisted parameters apply to the current page load only');
+r = run('?debugLibzimASM=wasm&useLibzim=true', PRODUCTION);
+check('an unlisted parameter is applied', r.params.debugLibzimASM === 'wasm');
+check('an unlisted parameter is not stored', !stored(r, 'debugLibzimASM'));
+check('an unlisted Boolean is converted', r.params.useLibzim === true);
+check('an unlisted Boolean is not stored', !stored(r, 'useLibzim'));
+
+section('Empty values clear a setting rather than being skipped');
+r = run('?allowInternetAccess=true&lastSelectedArchivePath=&lastSelectedArchive=my.zim', PRODUCTION);
+check('an empty value is parsed and clears the setting',
+    stored(r, 'lastSelectedArchivePath') && r.store.lastSelectedArchivePath === '');
+check('the parameter before an empty one is still parsed', r.store.allowInternetAccess === 'true');
+check('the parameter after an empty one is still parsed', r.store.lastSelectedArchive === 'my.zim');
+r = run('?kiwixDownloadServer=', PRODUCTION);
+check('an empty value does not satisfy an endpoint pattern', !stored(r, 'kiwixDownloadServer'));
+r = run('?sourceVerification=', DEV_SERVER);
+check('an empty value does not bypass a never-accepted parameter', !stored(r, 'sourceVerification'));
+
+section('The title parameter is reserved for the router');
+r = run('?title=A%2FSome_article', PRODUCTION);
+check('title is neither stored nor applied', !stored(r, 'title') && r.params.title === undefined);
+
+// ---------------------------------------------------------------------------------------------------
+
+console.log('\n' + (failures ? failures + ' of ' + total + ' checks FAILED' : 'All ' + total + ' checks passed') + '\n');
+process.exit(failures ? 1 : 0);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2005,8 +2005,11 @@ document.getElementById('allowInternetAccessCheck').addEventListener('change', f
                     var uriParams = '?allowInternetAccess=false&contentInjectionMode=jquery';
                     // Commented line below causes crash when there are too many archives
                     // uriParams += '&listOfArchives=' + encodeURIComponent(settingsStore.getItem('listOfArchives'));
-                    uriParams += '&lastSelectedArchive=' + encodeURIComponent(params.storedFile);
-                    uriParams += '&lastPageVisit=' + encodeURIComponent(params.lastPageVisit);
+                    // NB only send these when we have a value: an empty value now clears the setting on the
+                    // receiving side (see the parser in init.js), and we do not want to void a pointer there
+                    // merely because this instance has none
+                    uriParams += params.storedFile ? '&lastSelectedArchive=' + encodeURIComponent(params.storedFile) : '';
+                    uriParams += params.lastPageVisit ? '&lastPageVisit=' + encodeURIComponent(params.lastPageVisit) : '';
                     // Void the PWA_launch signal so that user will be asked again next time
                     params.localUWPSettings.PWA_launch = '';
                     window.location.href = 'ms-appx-web:///www/index.html' + uriParams;
@@ -3727,7 +3730,9 @@ function launchUWPServiceWorker () {
         uriParams += '&manipulateImages=false&allowHTMLExtraction=false';
         // Commented line below causes crash if there are too many archives
         // uriParams += '&listOfArchives=' + encodeURIComponent(settingsStore.getItem('listOfArchives'));
-        uriParams += '&lastSelectedArchive=' + encodeURIComponent(params.storedFile);
+        // NB only send this when we have a value: an empty value now clears the setting on the receiving side
+        // (see the parser in init.js), and we do not want to void the PWA's pointer if this instance has none
+        uriParams += params.storedFile ? '&lastSelectedArchive=' + encodeURIComponent(params.storedFile) : '';
         uriParams += params.packagedFile ? '&packagedFile=' + encodeURIComponent(params.packagedFile) : '';
         uriParams += params.fileVersion ? '&fileVersion=' + encodeURIComponent(params.fileVersion) : '';
         // Signal failure of PWA until it has successfully launched (in init.js it will be changed to 'success')

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -145,6 +145,9 @@ params['libzimSearchType'] = getSetting('libzimSearchType') || 'searchWithSnippe
 params['allowHTMLExtraction'] = getSetting('allowHTMLExtraction') === true;
 params['alphaChar'] = getSetting('alphaChar') || 'A'; // Set default start of alphabet string (used by the Archive Index)
 params['omegaChar'] = getSetting('omegaChar') || 'Z'; // Set default end of alphabet string
+// DEV: NW.js is excluded from the ServiceWorker default below because it primarily targets Windows XP. If that
+// changes, note that params.sourceVerification (set further down) becomes live in NW.js as a result, and NW.js
+// runs from file: - see the notes on the trusted context in overrideParams() below before altering this line.
 params['contentInjectionMode'] = getSetting('contentInjectionMode') || ((navigator.serviceWorker && !window.nw) ? 'serviceworker' : 'jquery'); // Deafault to SW mode if the browser supports it
 params['allowInternetAccess'] = getSetting('allowInternetAccess'); // Access disabled unless user specifically asked for it: NB allow this value to be null as we use it later
 params['openExternalLinksInNewTabs'] = getSetting('openExternalLinksInNewTabs') !== null ? getSetting('openExternalLinksInNewTabs') : true; // Parameter to turn on/off opening external links in new tab
@@ -188,18 +191,103 @@ params['lockDisplayOrientation'] = getSetting('lockDisplayOrientation'); // 'por
 params['noHiddenElementsWarning'] = getSetting('noHiddenElementsWarning') !== null ? getSetting('noHiddenElementsWarning') : false; // A one-time warning about Hidden elements display
 
 // Apply any override parameters in querystring (done as a self-calling function to avoid creating global variables)
+// Only the keys listed below are written to the Settings Store. Any other key is applied to the current page
+// load alone and is deliberately not stored, so that a crafted link cannot make a lasting change to the app's
+// configuration: DEV keeps the ability to drive any setting from the querystring while debugging, but the
+// setting reverts as soon as the app is reloaded without it.
 (function overrideParams () {
-    var rgx = /[?&]([^=]+)=([^&]+)/g;
+    // Parameters that may be set from the querystring and written to the Settings Store. These are the keys the
+    // app passes between its own contexts (the UWP <-> PWA handoffs in this file and in app.js, and the reload
+    // in resetApp.js), together with the cosmetic settings and the escape hatches DEV needs to break out of a
+    // boot loop. NB a handoff key only belongs here if it is read back from the Store at boot: params that are
+    // merely needed for the page load they arrive on (e.g. lastPageVisit) work correctly as session-only values.
+    var persistableParams = ['allowInternetAccess', 'contentInjectionMode', 'packagedFile', 'fileVersion',
+        'lastSelectedArchive', 'lastSelectedArchivePath', 'manipulateImages', 'allowHTMLExtraction',
+        'appCache', 'assetsCache', 'cssTheme', 'cssUITheme', 'hideActiveContentWarning', 'rememberLastPage'];
+
+    // Parameters that are never accepted from the querystring, in any context. The source verification prompt is
+    // the app's gate on opening an untrusted archive, and a stored "off" survives every subsequent visit, so a
+    // single crafted link must not be able to disarm it. It is deliberately not enough to gate this on a
+    // development origin: the app is documented as self-hostable via Docker (see README), where the user's own
+    // production instance is reached at http://localhost:<port> on a conventional port, and no origin test can
+    // tell that apart from a developer's dev server. DEV: set this once in Configuration, or from DevTools with
+    // localStorage.setItem('kiwixjs-sourceVerification', 'false') - both persist, so it is not a per-load cost.
+    var neverFromQuerystring = ['sourceVerification'];
+
+    // Parameters that weaken or bypass security-relevant behaviour, and are only ever needed when developing.
+    // They are honoured in a development context but ignored everywhere else, so that a crafted link to the
+    // production PWA cannot use them to disarm the app.
+    var devOnlyParams = ['noPrompts', 'PWAServer'];
+
+    // Parameters whose value must match a pattern before it will be accepted. These are the URL-shaped params:
+    // the OPDS catalogue and download endpoints, and the PWA jump target. Restricting them to the Kiwix domains
+    // stops a crafted link repointing the library or a download at a host of the attacker's choosing. NB the
+    // trailing group also permits the bare origin, as several of these defaults carry no trailing slash.
+    var kiwixServerPattern = /^https:\/\/(?:(?:[a-z0-9-]+\.)*kiwix\.org|kiwix\.github\.io)(?:[/?#]|$)/;
+    var validatedParams = {
+        kiwixLibraryServer: kiwixServerPattern,
+        kiwixLibraryBrowser: kiwixServerPattern,
+        kiwixCatalogRoot: kiwixServerPattern,
+        kiwixCatalogCategories: kiwixServerPattern,
+        kiwixCatalogEntries: kiwixServerPattern,
+        kiwixStagingCatalogEntries: kiwixServerPattern,
+        kiwixDownloadServer: kiwixServerPattern,
+        kiwixMirrorServer: kiwixServerPattern,
+        kiwixStagingServer: kiwixServerPattern,
+        PWAServer: kiwixServerPattern
+    };
+
+    // Keys that must never be copied onto the params object, because assigning them could alter the object's
+    // prototype chain rather than setting a parameter
+    var forbiddenParams = ['__proto__', 'constructor', 'prototype'];
+
+    // Determines whether we are running from a developer's own machine, as opposed to a shipped app. Note this
+    // is deliberately not a secure-context test: the production PWA is served over https, and it is precisely
+    // the context we must not trust with the parameters in devOnlyParams.
+    // The packaged app types are excluded before the origin is examined, because their origins are
+    // indistinguishable from a developer's: the Electron app serves itself from http://localhost via its
+    // bundled Express server, and NW.js runs from file:. Trusting those origins would trust every desktop
+    // install rather than the developer. DEV: this is why changing the default contentInjectionMode for NW.js
+    // (see params.contentInjectionMode above) does not open a hole here - do not reduce this to an origin test.
+    // Both clauses below still fire for the cases they are meant for, i.e. a browser pointed at the dev server
+    // on localhost, or at www/index.html opened directly from disk.
+    var trustedContext = !/Electron|UWP/.test(params.appType) &&
+        (/^(?:localhost|127\.0\.0\.1|\[::1\])$/.test(window.location.hostname) || /^file:$/.test(window.location.protocol));
+
+    // NB the value is [^&]* rather than [^&]+ so that an empty value is parsed rather than silently skipped:
+    // the UWP handoff clears a stale setting by sending it empty (e.g. '&lastSelectedArchivePath=' below),
+    // which never worked while the parser demanded at least one character. Senders that may legitimately have
+    // no value must therefore omit the parameter entirely rather than send it empty - see app.js. The pattern
+    // still cannot match an empty string overall (it needs at least '?x='), so the global exec loop terminates.
+    var rgx = /[?&]([^=]+)=([^&]*)/g;
     var matches = rgx.exec(window.location.search);
     while (matches) {
-        if (matches[1] && matches[2]) {
+        // NB test matches[2] against undefined, not truthiness: an empty value is meaningful here
+        if (matches[1] && matches[2] !== undefined) {
             var paramKey = decodeURIComponent(matches[1]);
             var paramVal = decodeURIComponent(matches[2]);
-            if (paramKey !== 'title') {
-                // Store new values
-                setSetting(paramKey, paramVal);
-                paramKey = paramKey === 'lastSelectedArchive' ? 'storedFile' : paramKey;
-                params[paramKey] = paramVal === 'false' ? false : paramVal === 'true' ? true : paramVal;
+            // The title key is a ZIM article path, which is consumed by the router rather than being a setting
+            if (paramKey !== 'title' && !~forbiddenParams.indexOf(paramKey)) {
+                // NB we must use hasOwnProperty here, or a key such as 'toString' would pick up an inherited
+                // function, which is truthy, and calling .test() on it would throw
+                var paramPattern = Object.prototype.hasOwnProperty.call(validatedParams, paramKey) ? validatedParams[paramKey] : null;
+                if (~neverFromQuerystring.indexOf(paramKey)) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": it can only be set in Configuration');
+                } else if (~devOnlyParams.indexOf(paramKey) && !trustedContext) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": it is only honoured when running from a development location');
+                } else if (paramPattern && !paramPattern.test(paramVal)) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": the value is not in the expected format');
+                } else {
+                    // Store new values
+                    // NB if we reach here with a devOnlyParams key, we are necessarily in a trusted context (see above)
+                    if (~persistableParams.indexOf(paramKey) || paramPattern || ~devOnlyParams.indexOf(paramKey)) {
+                        setSetting(paramKey, paramVal);
+                    } else {
+                        console.debug('Parameter "' + paramKey + '" applies to this page load only, and will not be stored');
+                    }
+                    paramKey = paramKey === 'lastSelectedArchive' ? 'storedFile' : paramKey;
+                    params[paramKey] = paramVal === 'false' ? false : paramVal === 'true' ? true : paramVal;
+                }
             }
         }
         matches = rgx.exec(window.location.search);
@@ -233,7 +321,7 @@ if (!/^http/i.test(window.location.protocol) && params.localUWPSettings &&
             var fal = Windows.Storage.AccessCache.StorageApplicationPermissions.futureAccessList;
             fal.addOrReplace(params.falFileToken, launchArgumentsUWP.files[0]);
             if (fal.containsItem(params.falFolderToken)) fal.remove(params.falFolderToken);
-            uriParams += '&lasSelectedArchivePath=&lastSelectedArchive=' + encodeURIComponent(launchArgumentsUWP.files[0].name);
+            uriParams += '&lastSelectedArchivePath=&lastSelectedArchive=' + encodeURIComponent(launchArgumentsUWP.files[0].name);
         }
         window.location.href = params.PWAServer + 'www/index.html' + uriParams;
         // This will trigger the error catching above, cleanly dematerialize this script and transport us swiftly to PWA land


### PR DESCRIPTION
Fixes #923.

Querystring parameters are now classified, rather than all being copied into `params` and written to the Settings Store:

- **`persistableParams`** — the settings the app hands between its own contexts (the UWP ↔ PWA handoffs in `init.js` and `app.js`, and the reload in `resetApp.js`), plus the cosmetic settings and the escape hatches needed to break out of a boot loop. A key belongs here only if `init.js` reads it back from the Store at boot, which is why `lastPageVisit` is not in it.
- **`neverFromQuerystring`** — `sourceVerification`, which is set in Configuration only.
- **`devOnlyParams`** — `noPrompts` and `PWAServer`, honoured only when running from a development location. The packaged app types are excluded from that test before the origin is examined, because the Electron app serves itself from `http://localhost` and NW.js runs from `file:`.
- **`validatedParams`** — the OPDS catalogue and download endpoints, and the PWA jump target, which must be Kiwix hosts.

Anything else applies to the current page load and is no longer stored, so a setting can still be driven from the querystring while debugging, but reverts on the next load without it.

Also in here:

- The parser now accepts an empty value, so sending a parameter empty clears the setting — which is what the UWP file-activation handoff has always intended but never achieved. The three senders that may legitimately have no value now omit the parameter rather than sending it empty.
- First tests for `init.js`. `npm test` runs 45 checks and adds no dependencies. `init.js` is a standalone script that is never bundled and cannot be required, so the tests slice `overrideParams()` out of the source and evaluate it against stubs, which keeps them running the real code rather than a copy that can drift from it. Two guards make a bad slice fail loudly rather than silently testing nothing.

Not wired into CI — worth a separate look at which workflow should own it.
