### PR TITLE
Handle the content injection mode string consistently, and do not race the archive trust prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## Interim release 3.8.91
+## Interim release 3.8.92
 
+* SECURITY/REGRESSION: An archive is no longer loaded in ServiceWorker mode while the security prompt about trusting its source is still showing
+* FIX: The content injection mode is now checked against the modes the app actually supports, so an unrecognized value can no longer leave the app in an invalid state
+* DEV: Harmonized the checks on the content injection mode string with upstream, and removed vestigial handling of a mode this app does not implement
+* DEV: Added unit tests covering the validation of the content injection mode value
 * SECURITY: Settings supplied in the app's URL are no longer saved permanently, apart from the few the app passes between its own windows, and source verification can now only be changed in Configuration
 * FEATURE: New setting to show a title bar when the browser draws the window controls overlay over the app, restoring the choice that recent versions of Edge removed
 * FEATURE: In-app library can now browse the whole ZIM catalogue as well as by category, so archives that declare no category in their metadata can now be found

--- a/test/overrideParams.test.cjs
+++ b/test/overrideParams.test.cjs
@@ -150,6 +150,9 @@ r = run('?contentInjectionMode=serviceworker&manipulateImages=false&allowHTMLExt
 check('contentInjectionMode is stored', r.store.contentInjectionMode === 'serviceworker');
 check('manipulateImages is stored', r.store.manipulateImages === 'false' && r.params.manipulateImages === false);
 check('allowHTMLExtraction is stored', r.store.allowHTMLExtraction === 'false');
+r = run('?allowInternetAccess=false&contentInjectionMode=jquery', PRODUCTION);
+check('contentInjectionMode accepts the app\'s other mode, used by the UWP handoff and resetApp',
+    r.store.contentInjectionMode === 'jquery');
 r = run('?lastPageVisit=A%2FSome_page', PRODUCTION);
 check('lastPageVisit applies to the current page load', r.params.lastPageVisit === 'A/Some_page');
 check('lastPageVisit is not stored, as init.js never reads it back under that key',
@@ -168,6 +171,16 @@ section('Endpoint parameters restricted to Kiwix hosts');
     r = run('?kiwixDownloadServer=' + encodeURIComponent(url), PRODUCTION);
     check('kiwixDownloadServer refuses ' + url,
         !stored(r, 'kiwixDownloadServer') && r.params.kiwixDownloadServer === undefined);
+});
+
+section('The content injection mode is restricted to the modes the app implements');
+// setContentInjectionMode() in app.js branches on 'jquery' and 'serviceworker' only, and the radio buttons in
+// index.html carry those same two values, so any other mode name leaves the app in a state it cannot show the
+// user: no radio button is selected, and the mode matches neither branch at the call sites that switch on it
+['serviceworkerlocal', 'jQuery', 'serviceworker ', 'anything'].forEach(function (mode) {
+    r = run('?contentInjectionMode=' + encodeURIComponent(mode), PRODUCTION);
+    check('contentInjectionMode refuses "' + mode + '"',
+        !stored(r, 'contentInjectionMode') && r.params.contentInjectionMode === undefined);
 });
 
 section('Keys that could alter the params prototype');

--- a/www/index.html
+++ b/www/index.html
@@ -104,6 +104,8 @@
                             <h3 style="margin-top:0;">Changes in version <span class="version">3.x</span></h3>
                             <ul style="padding-left: 15px;">
                                 <li>[New] Fixed security issue allowing for override of app's parameters with a malformed URL</li>
+                                <li>[New] An archive no longer loads in SW mode in the background before user has chosen the trust level</li>
+                                <li>[New] A content injection mode passed as a parameter is now checked against actually supported modes</li>
                                 <li>[New] Fixed the window buttons of recent Edge versions covering the app's own navigation buttons</li>
                                 <li>[New] Restored the draggable area for moving the app window</li>
                                 <li>[New] Setting in Configuration &gt; Display settings to emulate the title bar</li>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1933,6 +1933,11 @@ document.querySelectorAll('input[name="contentInjectionMode"][type="radio"]').fo
         // Do the necessary to enable or disable the Service Worker
         setContentInjectionMode(this.value);
 
+        // Set below if the user has to be asked whether they trust the loaded archive. The article reload
+        // at the foot of this handler must wait for that answer, because declining switches the app back
+        // to Restricted mode, and reloading first would load the archive in Service Worker mode regardless
+        var verifyingArchive = null;
+
         /** DEV: PLEASE NOTE THAT "jQuery mode" HAS NOW CHANGED to "Restricted mode", but we still use "jquery" in code */
 
         // Actions that must be completed after switch to Restricted mode
@@ -1952,7 +1957,7 @@ document.querySelectorAll('input[name="contentInjectionMode"][type="radio"]').fo
             document.getElementById('enableSourceVerificationCheck').style.display = '';
             if (params.sourceVerification && appstate.selectedArchive && appstate.selectedArchive.isReady() && appstate.selectedArchive.file._files[0].name !== params.packagedFile &&
               !settingsStore.getItem('trustedZimFiles').includes(appstate.selectedArchive.file.name)) {
-                verifyLoadedArchive(appstate.selectedArchive);
+                verifyingArchive = verifyLoadedArchive(appstate.selectedArchive);
             }
             if (params.manipulateImages || params.allowHTMLExtraction) {
                 if (!appstate.wikimediaZimLoaded) {
@@ -1967,15 +1972,25 @@ document.querySelectorAll('input[name="contentInjectionMode"][type="radio"]').fo
         }
         // Reload the currently displayed article straight away, so that anchor click handling
         // (which differs between Restricted and Service Worker mode) is applied to the page that
-        // is already open, instead of only taking effect on the next navigation
-        if (appstate.selectedArchive && appstate.selectedArchive.isReady()) {
-            if (params.lastPageVisit) {
-                goToArticle(params.lastPageVisit.replace(/@[^@].+$/, ''));
-            } else {
-                goToMainArticle();
+        // is already open, instead of only taking effect on the next navigation. NB if the user is
+        // being asked whether they trust the archive, this must not run until they have answered:
+        // params.contentInjectionMode is only switched back to 'jquery' when they decline, so an
+        // immediate reload would load the archive in Service Worker mode whatever the answer
+        var reloadCurrentArticle = function () {
+            if (appstate.selectedArchive && appstate.selectedArchive.isReady()) {
+                if (params.lastPageVisit) {
+                    goToArticle(params.lastPageVisit.replace(/@[^@].+$/, ''));
+                } else {
+                    goToMainArticle();
+                }
             }
+            params.themeChanged = false;
+        };
+        if (verifyingArchive) {
+            verifyingArchive.then(reloadCurrentArticle);
+        } else {
+            reloadCurrentArticle();
         }
-        params.themeChanged = false;
     });
 });
 document.getElementById('allowInternetAccessCheck').addEventListener('change', function () {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2215,8 +2215,11 @@ document.getElementById('disableDragAndDropCheck').addEventListener('change', fu
         }
     });
 });
-// Source verification is only makes sense in SW mode as doing the same in jQuery mode is redundant.
-document.getElementById('enableSourceVerificationCheck').style.display = params.contentInjectionMode === ('serviceworker' || 'serviceworkerlocal') ? 'block' : 'none';
+// Source verification only makes sense in SW mode, as doing the same in jQuery mode is redundant.
+// NB test the start of the mode string, as init.js does when reading params.sourceVerification back: the
+// parenthesized ('serviceworker' || 'serviceworkerlocal') this replaces short-circuited to its first operand,
+// so it was only ever an exact match on 'serviceworker'
+document.getElementById('enableSourceVerificationCheck').style.display = /^serviceworker/.test(params.contentInjectionMode) ? 'block' : 'none';
 document.getElementById('enableSourceVerificationCheck').addEventListener('change', function () {
     params.sourceVerification = this.checked;
     settingsStore.setItem('sourceVerification', this.checked, Infinity);
@@ -4960,16 +4963,13 @@ function archiveReadyCallback (archive) {
     // Set contentInjectionMode to serviceWorker when opening a new archive in case the user switched to Restricted mode/jQuery Mode when opening the previous archive
     if (params.contentInjectionMode === 'jquery') {
         params.contentInjectionMode = settingsStore.getItem('contentInjectionMode');
-        // Change the radio buttons accordingly
-        switch (settingsStore.getItem('contentInjectionMode')) {
-            case 'serviceworker':
-                document.getElementById('serviceworkerModeRadio').checked = true;
-                // In case we atuo-switched off assetsCache due to switch to Restricted mode, we need to reset
-                params.assetsCache = settingsStore.getItem('asetsCache') !== 'false';
-                break;
-            case 'serviceworkerlocal':
-                document.getElementById('serviceworkerLocalModeRadio').checked = true;
-                break;
+        // Change the radio buttons accordingly. NB there was formerly a 'serviceworkerlocal' case here, copied
+        // from upstream kiwix-js, but this app has no such mode and no serviceworkerLocalModeRadio element, so
+        // that branch could only ever have thrown on a null element
+        if (settingsStore.getItem('contentInjectionMode') === 'serviceworker') {
+            document.getElementById('serviceworkerModeRadio').checked = true;
+            // In case we atuo-switched off assetsCache due to switch to Restricted mode, we need to reset
+            params.assetsCache = settingsStore.getItem('asetsCache') !== 'false';
         }
     }
     if (settingsStore.getItem('trustedZimFiles') === null) {

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -148,7 +148,11 @@ params['omegaChar'] = getSetting('omegaChar') || 'Z'; // Set default end of alph
 // DEV: NW.js is excluded from the ServiceWorker default below because it primarily targets Windows XP. If that
 // changes, note that params.sourceVerification (set further down) becomes live in NW.js as a result, and NW.js
 // runs from file: - see the notes on the trusted context in overrideParams() below before altering this line.
-params['contentInjectionMode'] = getSetting('contentInjectionMode') || ((navigator.serviceWorker && !window.nw) ? 'serviceworker' : 'jquery'); // Deafault to SW mode if the browser supports it
+// NB the stored value is checked against the modes this app actually supports, and anything else falls back to
+// the default: an unrecognized mode matches neither branch of setContentInjectionMode() in app.js, which leaves
+// the app in a hybrid state with no radio button selected. This also heals a value stored before that was so
+params['contentInjectionMode'] = /^(?:jquery|serviceworker)$/.test(getSetting('contentInjectionMode'))
+    ? getSetting('contentInjectionMode') : ((navigator.serviceWorker && !window.nw) ? 'serviceworker' : 'jquery'); // Deafault to SW mode if the browser supports it
 params['allowInternetAccess'] = getSetting('allowInternetAccess'); // Access disabled unless user specifically asked for it: NB allow this value to be null as we use it later
 params['openExternalLinksInNewTabs'] = getSetting('openExternalLinksInNewTabs') !== null ? getSetting('openExternalLinksInNewTabs') : true; // Parameter to turn on/off opening external links in new tab
 params['disableDragAndDrop'] = getSetting('disableDragAndDrop') === true; // A parameter to disable drag-and-drop
@@ -157,7 +161,11 @@ params['rightClickType'] = getSetting('rightClickType'); // 'single|double|false
 params['navButtonsPos'] = getSetting('navButtonsPos') || 'bottom'; // 'top|bottom' A setting that determines where the back-forward nav buttons appear
 params['useOPFS'] = getSetting('useOPFS') === true; // A setting that determines whether to use OPFS (experimental)
 params['useLegacyZimitSupport'] = getSetting('useLegacyZimitSupport') === true; // A setting that determines whether to force the use of legacy Zimit support
-params['sourceVerification'] = params.contentInjectionMode === 'serviceworker' ? (getSetting('sourceVerification') === null ? true : getSetting('sourceVerification')) : false; // Sets a boolean indicating weather a user trusts the source of zim files
+// Sets a boolean indicating whether a user trusts the source of zim files. NB this tests the start of the mode
+// string rather than matching it exactly, both because the gate in app.js does the same and because upstream
+// kiwix-js has a further 'serviceworkerlocal' mode: an exact match would silently leave the gate off in any
+// mode whose name merely begins with 'serviceworker'
+params['sourceVerification'] = /^serviceworker/.test(params.contentInjectionMode) ? (getSetting('sourceVerification') === null ? true : getSetting('sourceVerification')) : false;
 params['interceptBeforeUnload'] = getSetting('interceptBeforeUnload') !== null ? getSetting('interceptBeforeUnload') : true; // A setting that determines whether to warn user before leaving the app (default is true)
 params['autoUpdatePWA'] = getSetting('autoUpdatePWA') !== false; // A setting that determines whether to auto-update the PWA without asking the user (default is true)
 params['keepTorrentSeeding'] = getSetting('keepTorrentSeeding') !== false; // A setting that determines whether completed in-app BitTorrent downloads keep seeding until app quit (default is true; Electron/NWJS only)
@@ -219,12 +227,16 @@ params['noHiddenElementsWarning'] = getSetting('noHiddenElementsWarning') !== nu
     // production PWA cannot use them to disarm the app.
     var devOnlyParams = ['noPrompts', 'PWAServer'];
 
-    // Parameters whose value must match a pattern before it will be accepted. These are the URL-shaped params:
+    // Parameters whose value must match a pattern before it will be accepted. Most are the URL-shaped params:
     // the OPDS catalogue and download endpoints, and the PWA jump target. Restricting them to the Kiwix domains
     // stops a crafted link repointing the library or a download at a host of the attacker's choosing. NB the
     // trailing group also permits the bare origin, as several of these defaults carry no trailing slash.
+    // contentInjectionMode is here for a different reason: it is a mode name rather than a URL, and a value the
+    // app does not recognize leaves it in a state its own UI cannot represent (see params.contentInjectionMode
+    // above). The two names below are the values of the radio buttons in index.html.
     var kiwixServerPattern = /^https:\/\/(?:(?:[a-z0-9-]+\.)*kiwix\.org|kiwix\.github\.io)(?:[/?#]|$)/;
     var validatedParams = {
+        contentInjectionMode: /^(?:jquery|serviceworker)$/,
         kiwixLibraryServer: kiwixServerPattern,
         kiwixLibraryBrowser: kiwixServerPattern,
         kiwixCatalogRoot: kiwixServerPattern,


### PR DESCRIPTION
Two related fixes around the content injection mode and the archive trust prompt. Both were found while porting kiwix/kiwix-js#1470, and both are reproducible in the app.

## 1. Handle the content injection mode string consistently (920cf749)

`init.js` compared `params.contentInjectionMode` for exact equality with `'serviceworker'` when deciding whether to read `sourceVerification` back from the Settings Store, while the trust gate in `app.js` tests `/^serviceworker/`. Upstream that mismatch left the gate off on every launch in its ServiceWorkerLocal mode, which is what kiwix/kiwix-js#1470 fixes. **This app has no such mode**, so the read-back is aligned for parity rather than to close a live gap — but the two tests should not disagree about what a Service Worker mode is.

The same exact-match error was also hiding the source verification checkbox in Configuration:

```js
params.contentInjectionMode === ('serviceworker' || 'serviceworkerlocal')
```

The parenthesised `||` short-circuits to its first operand, so this was never the two-way test it appears to be.

Testing the querystring override then showed the underlying issue: `contentInjectionMode` is in `persistableParams` and accepted **any** value, which it persisted. `setContentInjectionMode()` branches on `'jquery'` and `'serviceworker'` only, so an unrecognised mode left the app in a hybrid state with neither radio button selected. It self-heals at the next archive-trust prompt, which writes a real mode back, but it should not be reachable at all. The mode is now checked against the two radio button values in `index.html`, both when it arrives in the querystring and when it is read back from the Store — so a value stored before this change is healed too.

Also removes a vestigial `case 'serviceworkerlocal'` in `archiveReadyCallback()`, copied from upstream, which referenced a `serviceworkerLocalModeRadio` element that does not exist here and so could only ever have thrown on a null element.

Upstream's third hunk (`defaultModeChangeAlertDisplayed`) does not apply — that parameter does not exist in this repo.

## 2. Wait for the archive trust answer before reloading the article (1ec0a9c6)

Switching from Restricted to Service Worker mode with an untrusted archive open loaded that archive in Service Worker mode **while the trust prompt was still on screen**, and did so whatever the user then answered.

The radio button handler calls `verifyLoadedArchive()` without awaiting it. That was harmless while the handler ended in `params.themeChanged = true`, because the reload was then deferred to the next navigation and so happened after the user had answered. #879 replaced that with an immediate `goToArticle()`/`goToMainArticle()`, which races the prompt: `verifyLoadedArchive()` only sets `params.contentInjectionMode` back to `'jquery'` when the user declines, and by then the article is already loading in the mode they were declining.

The reload now runs from the promise when verification is pending, and directly when it is not, so it always sees the mode the user actually chose. Note that declining remains **session-only** by design — it means "open this ZIM in Restricted mode for now", not "switch the whole app to Restricted mode for every ZIM" — so `setContentInjectionMode()` is deliberately not called there.

## Testing

`test/overrideParams.test.cjs` gains 5 checks (50 pass, lint clean). They are mutation-verified: removing the `contentInjectionMode` entry from `validatedParams` fails 4 of them.

The `app.js` changes are not covered by that harness and were verified by hand in the running app: the checkbox visibility, the radio state after opening an archive when switching out of Restricted mode, and the trust prompt no longer being raced by the article load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
