### PR TITLE
Fix the Zimit and legacy ZIM warnings, and make alert links legible in dark mode (#928, #902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,16 @@
 
 ## Interim release 3.8.92
 
-* FIX: An archive opened after the app has temporarily switched itself to Restricted mode now has its Service Worker mode settings applied again, instead of opening with the app still set up for the mode it had left behind
-* REGRESSION: A historical archive such as `wikipedia_en_wp1-0.5_2007-03.zim` no longer opens with broken styling and no explanation, now that the advice to read it in Restricted mode is shown again; the app also switches to that mode for you, since it is the only one that can find such an archive's stylesheets, and your own choice of mode returns as soon as you open any other archive
-* FIX: The warning about limited Zimit support is now shown for zimit2 archives in Restricted mode, where it was silently skipped
-* FIX: The warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader for an archive its browser cannot handle
-* FIX: Links in the active content warnings are now legible in dark mode, instead of light blue on the warning's yellow background
-* FIX: Developer Mode can now be turned on and off while the app is in Restricted mode, instead of being refused with an alert that left the checkbox showing the opposite of the setting it controls
-* ENHANCEMENT: Developer Mode now also turns off the ZIM assets cache for as long as it is on, and marks those buttons unavailable, so the mode genuinely runs the app with no caches at all; your own choice of assets cache returns when you turn Developer Mode off
-* FIX: A misspelt setting name meant the ZIM assets cache was silently switched back on, whatever you had chosen, whenever the app returned to Service Worker mode after opening an archive
-* REGRESSION: Restored the warnings about active content, and about limited support for Zimit archives, which have been invisible since the Bootstrap 4 migration
-* FIX: Reset app no longer fails with an error, leaving the app unreset, when no Service Worker is controlling the page
-* SECURITY/REGRESSION: An archive is no longer loaded in ServiceWorker mode while the security prompt about trusting its source is still showing
+* FIX: Mode now restored to Service Worker on next ZIM load if app has temporarily switched itself to Restricted mode
+* REGRESSION: App now auto-switches to appropriate display mode when openinig historical Wikipedia archives
+* REGRESSION: Warning about limited Zimit support now shown for zimit2 archives in Restricted mode, where it was silently skipped
+* REGRISSION: Warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader
+* REGRESSION: Links in the active content warnings are now legible in dark mode
+* DEV: Developer Mode can now be turned on and off while the app is in Restricted mode
+* DEV: Developer Mode now also turns off the ZIM assets cache for as long as it is on, and marks those buttons unavailable
+* FIX: A misspelt setting name meant the app ignored user choice to disable assets cache
+* FIX: Reset app no longer fails with an error when no Service Worker is controlling the page
+* SECURITY/REGRESSION: Archives no longer loaded in SW mode in the background before user has chosen the trust level
 * FIX: The content injection mode is now checked against the modes the app actually supports, so an unrecognized value can no longer leave the app in an invalid state
 * DEV: Harmonized the checks on the content injection mode string with upstream, and removed vestigial handling of a mode this app does not implement
 * DEV: Added unit tests covering the validation of the content injection mode value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Interim release 3.8.92
 
-* REGRESSION: Opening a historical archive such as `wikipedia_en_wp1-0.5_2007-03.zim` again switches automatically to Restricted mode, the only mode that can find the stylesheets of such an archive, and says so in a banner; the app returns to your chosen mode when you next open any other archive
+* REGRESSION: A historical archive such as `wikipedia_en_wp1-0.5_2007-03.zim` no longer opens with broken styling and no explanation, now that the advice to read it in Restricted mode is shown again; the app also switches to that mode for you, since it is the only one that can find such an archive's stylesheets, and your own choice of mode returns as soon as you open any other archive
 * FIX: The warning about limited Zimit support is now shown for zimit2 archives in Restricted mode, where it was silently skipped
 * FIX: The warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader for an archive its browser cannot handle
 * FIX: Links in the active content warnings are now legible in dark mode, instead of light blue on the warning's yellow background

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Interim release 3.8.92
 
+* REGRESSION: Opening a historical archive such as `wikipedia_en_wp1-0.5_2007-03.zim` again switches automatically to Restricted mode, the only mode that can find the stylesheets of such an archive, and says so in a banner; the app returns to your chosen mode when you next open any other archive
 * FIX: The warning about limited Zimit support is now shown for zimit2 archives in Restricted mode, where it was silently skipped
 * FIX: The warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader for an archive its browser cannot handle
 * FIX: Links in the active content warnings are now legible in dark mode, instead of light blue on the warning's yellow background

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Interim release 3.8.92
 
+* FIX: The warning about limited Zimit support is now shown for zimit2 archives in Restricted mode, where it was silently skipped
+* FIX: The warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader for an archive its browser cannot handle
+* FIX: Links in the active content warnings are now legible in dark mode, instead of light blue on the warning's yellow background
 * FIX: Developer Mode can now be turned on and off while the app is in Restricted mode, instead of being refused with an alert that left the checkbox showing the opposite of the setting it controls
 * ENHANCEMENT: Developer Mode now also turns off the ZIM assets cache for as long as it is on, and marks those buttons unavailable, so the mode genuinely runs the app with no caches at all; your own choice of assets cache returns when you turn Developer Mode off
 * FIX: A misspelt setting name meant the ZIM assets cache was silently switched back on, whatever you had chosen, whenever the app returned to Service Worker mode after opening an archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Interim release 3.8.92
 
+* FIX: An archive opened after the app has temporarily switched itself to Restricted mode now has its Service Worker mode settings applied again, instead of opening with the app still set up for the mode it had left behind
 * REGRESSION: A historical archive such as `wikipedia_en_wp1-0.5_2007-03.zim` no longer opens with broken styling and no explanation, now that the advice to read it in Restricted mode is shown again; the app also switches to that mode for you, since it is the only one that can find such an archive's stylesheets, and your own choice of mode returns as soon as you open any other archive
 * FIX: The warning about limited Zimit support is now shown for zimit2 archives in Restricted mode, where it was silently skipped
 * FIX: The warning about legacy support for Zimit archives is now shown when the app falls back to the legacy reader for an archive its browser cannot handle

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -1060,6 +1060,14 @@ pre {
     color: lightblue !important;
 }
 
+/* Bootstrap draws the links in an alert in a darker shade of the alert's own palette (.alert-warning
+   .alert-link is #533f03), but the blanket dark mode link colour above overrides it, leaving light blue
+   on the warning alert's yellow, which is barely legible. The active content warnings keep their light
+   theme colours in both themes, so their links must do the same [kiwix-js-pwa #928] */
+.dark .alert-warning a {
+    color: #533f03 !important;
+}
+
 .darkfooter .btn-default {
     background: rgba(34,34,34,0) !important;
     color: lightblue !important;

--- a/www/index.html
+++ b/www/index.html
@@ -104,7 +104,8 @@
                             <h3 style="margin-top:0;">Changes in version <span class="version">3.x</span></h3>
                             <ul style="padding-left: 15px;">
                                 <li>[New] Fixed security issue allowing for override of app's parameters with a malformed URL</li>
-                                <li>[New] An archive no longer loads in SW mode in the background before user has chosen the trust level</li>
+                                <li>[New] Archives are no longer loaded in the background before user has chosen the trust level</li>
+                                <li>[New] Active content warnings and limited display mode warnings now restored</li>
                                 <li>[New] A content injection mode passed as a parameter is now checked against actually supported modes</li>
                                 <li>[New] Fixed the window buttons of recent Edge versions covering the app's own navigation buttons</li>
                                 <li>[New] Restored the draggable area for moving the app window</li>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4864,6 +4864,23 @@ function archiveReadyCallback (archive) {
     // When a new ZIM is loaded, we turn this flag to null, so that we don't get false positive attempts to use the Worker
     // It will be defined as false or true when the first article is loaded
     appstate.isReplayWorkerAvailable = null;
+    // Restore the user's own content injection mode when opening a new archive, in case the app switched to
+    // Restricted mode for the previous one (it does that for a historical ZIM, and when the user declines the
+    // trust prompt, in both cases by changing params only, so the Store still holds their real choice).
+    // DEV: This has to run before anything below reads the mode, or the archive that follows such a switch would
+    // silently skip the Service Worker initialization and the mode-dependent defaults [kiwix-js-pwa #929]
+    if (params.contentInjectionMode === 'jquery') {
+        var storedContentInjectionMode = settingsStore.getItem('contentInjectionMode');
+        // NB there was formerly a 'serviceworkerlocal' case here, copied from upstream kiwix-js, but this app has
+        // no such mode and no serviceworkerLocalModeRadio element, so that branch could only ever have thrown on a
+        // null element. An unrecognized or missing stored value is ignored rather than assigned, which would leave
+        // the mode in a state the app's own UI cannot represent (see params.contentInjectionMode in init.js)
+        if (/^(?:jquery|serviceworker)$/.test(storedContentInjectionMode)) {
+            params.contentInjectionMode = storedContentInjectionMode;
+            // Change the radio buttons accordingly
+            if (storedContentInjectionMode === 'serviceworker') document.getElementById('serviceworkerModeRadio').checked = true;
+        }
+    }
     // Initialize the Service Worker
     if (params.contentInjectionMode === 'serviceworker') {
         initServiceWorkerMessaging();
@@ -4874,6 +4891,7 @@ function archiveReadyCallback (archive) {
     appstate.wikimediaZimLoaded = /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(archive.file.name);
     appstate.zimThemeType = 'desktop';
     appstate.pureMode = false;
+    appstate.legacyModeSwitched = false;
     // Reset params.assetsCache in case it was changed below
     params.assetsCache = cache.assetsCacheAllowed();
     params.imageDisplayMode = params.imageDisplay ? 'progressive' : 'manual';
@@ -4997,18 +5015,6 @@ function archiveReadyCallback (archive) {
             }
         }
     };
-    // Set contentInjectionMode to serviceWorker when opening a new archive in case the user switched to Restricted mode/jQuery Mode when opening the previous archive
-    if (params.contentInjectionMode === 'jquery') {
-        params.contentInjectionMode = settingsStore.getItem('contentInjectionMode');
-        // Change the radio buttons accordingly. NB there was formerly a 'serviceworkerlocal' case here, copied
-        // from upstream kiwix-js, but this app has no such mode and no serviceworkerLocalModeRadio element, so
-        // that branch could only ever have thrown on a null element
-        if (settingsStore.getItem('contentInjectionMode') === 'serviceworker') {
-            document.getElementById('serviceworkerModeRadio').checked = true;
-            // In case we auto-switched off assetsCache due to switch to Restricted mode, we need to reset
-            params.assetsCache = cache.assetsCacheAllowed();
-        }
-    }
     if (settingsStore.getItem('trustedZimFiles') === null) {
         settingsStore.setItem('trustedZimFiles', '', Infinity);
     }
@@ -6962,6 +6968,9 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
         console.debug('Historical ZIM detected: switching to Restricted mode so that its stylesheets can be found');
         params.contentInjectionMode = 'jquery';
         document.getElementById('jQueryModeRadio').checked = true;
+        // The gate below only lets the landing page raise a warning, but an archive reopened at its last visited
+        // page never reaches it, so flag the switch to be announced on the second pass whatever page we are on
+        appstate.legacyModeSwitched = true;
         return readArticle(dirEntry);
     }
     params.isLandingPage = appstate.selectedArchive.landingPageUrl === dirEntry.namespace + '/' + dirEntry.url
@@ -6972,7 +6981,8 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
     }
 
     // Display Bootstrap warning alert if the landing page contains active content
-    if (!params.hideActiveContentWarning && (params.isLandingPage || appstate.selectedArchive.zimitStartPage === dirEntry.namespace + '/' + dirEntry.url) &&
+    if (!params.hideActiveContentWarning && (params.isLandingPage || appstate.legacyModeSwitched ||
+        appstate.selectedArchive.zimitStartPage === dirEntry.namespace + '/' + dirEntry.url) &&
         (params.contentInjectionMode === 'jquery' || params.manipulateImages || params.allowHTMLExtraction || /zimit/.test(appstate.selectedArchive.zimType))) {
         if (params.isLegacyZIM || regexpActiveContent.test(htmlArticle)) {
             // Exempted scripts: active content warning will not be displayed if any listed script is in the html [kiwix-js #889]
@@ -6983,6 +6993,9 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
             }
         }
     }
+    // The switch is explained once, on the pass that follows it: clear the flag whether or not the conditions
+    // above were met, so that it cannot raise a warning on some later article of the same archive
+    appstate.legacyModeSwitched = false;
 
     // App appears to have successfully launched
     params.appIsLaunching = false;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6565,7 +6565,9 @@ function handleUnsupportedReplayWorker (unhandledDirEntry) {
     // params.contentInjectionMode = 'jquery';
     readArticle(unhandledDirEntry);
     if (!params.hideActiveContentWarning) {
-        uiUtil.displayActiveContentWarning();
+        // We only get here for a classic Zimit archive that has to fall back to the legacy reader, so name the type:
+        // called with no argument, the warning silently matched none of its branches and nothing was shown [kiwix-js-pwa #928]
+        uiUtil.displayActiveContentWarning('zimit');
         return uiUtil.systemAlert('<p>You are attempting to open a Zimit (classic) archive, ' +
             'which is not fully supported by your browser in ServiceWorker(Local) mode.</p><p>We are using a legacy ' +
             'fallback method to read this archive, but some highly dynamic content may not work.</p>',

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6950,6 +6950,20 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
     if (params.zimType === 'open') {
         params.isLegacyZIM = /<link\b[^>]+href\s*=\s*["']\/[^."']+\.css["']/i.test(htmlArticle);
     }
+    // A historical ZIM gives the paths to its assets as root-relative URLs, which are not parsed in Service Worker
+    // mode, so switch to Restricted mode (which parses them more leniently) and read the article again. The banner
+    // explaining the switch is raised by the gate below on that second pass, when the mode is no longer 'serviceworker'.
+    // DEV: The switch is deliberately to params only, exactly as when the user declines the trust prompt in
+    // verifyLoadedArchive(): the Settings Store keeps the user's real choice, so opening any non-legacy archive
+    // afterwards restores it (see the block at the head of archiveReadyCallback). It is also deliberately outside the
+    // gate below, whose Service Worker mode conditions are about the app's own image and HTML processing, and so left
+    // a historical ZIM entirely unhandled at default settings [kiwix-js-pwa #902]
+    if (params.isLegacyZIM && params.contentInjectionMode === 'serviceworker') {
+        console.debug('Historical ZIM detected: switching to Restricted mode so that its stylesheets can be found');
+        params.contentInjectionMode = 'jquery';
+        document.getElementById('jQueryModeRadio').checked = true;
+        return readArticle(dirEntry);
+    }
     params.isLandingPage = appstate.selectedArchive.landingPageUrl === dirEntry.namespace + '/' + dirEntry.url
         ? true : params.isLandingPage;
     // Due to fast article retrieval algorithm, we need to embed a reference to the landing page in the html
@@ -6966,11 +6980,6 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
                 setTimeout(function () {
                     uiUtil.displayActiveContentWarning(params.isLegacyZIM ? 'legacy' : params.zimType);
                 }, 1500);
-            }
-            if (params.isLegacyZIM && params.contentInjectionMode === 'serviceworker') {
-                // Pop up a dialogue box to warn the user about the legacy ZIM
-                uiUtil.systemAlert('<p>To view this legacy ZIM archive with its correct stylesheets, you will need to switch to Restricted mode.</p>' +
-                    "<p>Don't forget to switch back afterwards!</p>", 'Legacy ZIM file');
             }
         }
     }

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -614,9 +614,11 @@ function displayActiveContentWarning (type) {
             'You may need to increase font size with zoom buttons at bottom of screen.&nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
         '</div>';
     } else if (/^zimit/.test(type)) {
-        // DEV: Zimit2 archives are fully supported in Service Worker mode, where the Service Worker serves them
-        // directly (see appstate.pureMode in app.js), so there is nothing to warn about; but in Restricted mode
-        // they are as limited as classic Zimit archives, so they get the same warning [kiwix-js-pwa #928]
+        // DEV: This warning tells the user that what they are seeing is an approximation of the ZIM's content, so it
+        // belongs to Restricted mode. In Service Worker mode a modern browser renders these archives properly and
+        // there is nothing to warn about; the only exception is a classic Zimit archive whose browser cannot run the
+        // Replay worker, which falls back to the legacy reader (see handleUnsupportedReplayWorker in app.js) and does
+        // warn below. Zimit2 has no such fallback, so it warns in Restricted mode only [kiwix-js-pwa #928]
         if (type === 'zimit2' && params.contentInjectionMode !== 'jquery') return;
         alertHTML =
         '<div id="activeContent" class="alert alert-warning alert-dismissible fade show" style="margin-bottom: 0;">' +

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -592,7 +592,7 @@ function getClosestMatchForTagname (el, rgx) {
 
 /**
  * Displays a Bootstrap warning alert with information about how to access content in a ZIM with unsupported active UI
- * @param {String} type The ZIM archive type ('open', 'zimit', or 'legacy')
+ * @param {String} type The ZIM archive type ('open', 'zimit', 'zimit2', or 'legacy')
  */
 function displayActiveContentWarning (type) {
     // We have to add the alert box in code, because Bootstrap removes it completely from the DOM when the user dismisses it
@@ -613,7 +613,11 @@ function displayActiveContentWarning (type) {
             'please <a id="jqModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to the legacy Restricted mode</a>. ' +
             'You may need to increase font size with zoom buttons at bottom of screen.&nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
         '</div>';
-    } else if (type === 'zimit') {
+    } else if (/^zimit/.test(type)) {
+        // DEV: Zimit2 archives are fully supported in Service Worker mode, where the Service Worker serves them
+        // directly (see appstate.pureMode in app.js), so there is nothing to warn about; but in Restricted mode
+        // they are as limited as classic Zimit archives, so they get the same warning [kiwix-js-pwa #928]
+        if (type === 'zimit2' && params.contentInjectionMode !== 'jquery') return;
         alertHTML =
         '<div id="activeContent" class="alert alert-warning alert-dismissible fade show" style="margin-bottom: 0;">' +
             '<a href="#" id="activeContentClose" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -606,11 +606,14 @@ function displayActiveContentWarning (type) {
             '<b><i>space / </i></b>, or else <a id="swModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to Service Worker mode</a> ' +
             'if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
         '</div>';
-    } else if (params.contentInjectionMode === 'serviceworker' && type === 'legacy') {
+    } else if (type === 'legacy') {
+        // DEV: The app now switches to Restricted mode by itself when it meets a historical ZIM, so this no longer
+        // asks the user to do it; the wording holds whether the app switched or the user was already in that mode,
+        // and the link takes them to the setting in case they want to change it back [kiwix-js-pwa #902]
         alertHTML = '<div id="activeContent" class="alert alert-warning alert-dismissible fade show" style="margin-bottom: 0;">' +
             '<a href="#" id="activeContentClose" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +
-        '<strong>Legacy ZIM type!</strong> To display content correctly from this historical ZIM, ' +
-            'please <a id="jqModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to the legacy Restricted mode</a>. ' +
+        '<strong>Legacy ZIM type!</strong> This historical ZIM can only be displayed correctly in the legacy ' +
+            '<a id="jqModeLink" href="#contentInjectionModeDiv" class="alert-link">Restricted mode</a>, which is now in use. ' +
             'You may need to increase font size with zoom buttons at bottom of screen.&nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
         '</div>';
     } else if (/^zimit/.test(type)) {


### PR DESCRIPTION
Completes #928. The `fade in` → `fade show` fix in #927 made the active content warnings visible again; testing then showed the two remaining problems recorded in that issue.

### The rule these warnings follow

The active content warning tells the user that what they are seeing is an **approximation** of the ZIM's content and that things may fail, so it belongs to Restricted mode. In Service Worker mode a modern browser renders dynamic archives properly and there is nothing to warn about — whether the archive is Zimit classic, zimit2 or any other dynamic type. The only Service Worker mode exceptions are the cases where the app genuinely cannot serve the content properly: a very old ZIM (the `'legacy'` branch), a classic Zimit archive whose browser cannot run the Replay worker and falls back to the legacy reader, and the case where the user has explicitly re-enabled the app's own image manipulation / hidden block elements / HTML extraction processing. Those three are unchanged by this PR.

### zimit2 archives got no warning at all

`displayActiveContentWarning()` matched the exact string `'zimit'`, so a zimit2 archive fell through every branch to the silent `else { return; }` at the end of the function. The branch now matches `/^zimit/`.

In **Restricted mode** a zimit2 archive is as limited as a classic one, so it gets the same "Limited Zimit support!" warning. In **Service Worker mode** it returns early, per the rule above: zimit2 has no legacy-reader fallback (that path is classic-only), so Restricted mode is the only mode in which it can warn. Showing classic Zimit's "Legacy support… audio/video may fail" wording there would have been untrue of zimit2.

### The legacy fallback passed no type

`handleUnsupportedReplayWorker()` called `uiUtil.displayActiveContentWarning()` with no argument, so `type` was `undefined` and it too matched no branch. That path is only reached by a classic Zimit archive falling back to the legacy reader — one of the Service Worker mode exceptions above — so it now names the type and the persistent warning accompanies its modal as intended.

### Alert links were illegible in dark mode

`.dark a { color: lightblue !important }` overrode the colour Bootstrap gives `.alert-link`, so the links rendered light blue on the warning alert's yellow. The alerts keep their light theme palette in both themes, so `.dark .alert-warning a` now restores Bootstrap's own `#533f03`. Scoped to `.alert-warning`, which only `displayActiveContentWarning()` uses — the `alert-info` boxes (download, upgrade) have their own dark treatment and are untouched.

Lint clean, 50/50 tests pass. CHANGELOG updated.
