### PR TITLE
Follow HTML redirect stubs in Restricted mode (#931)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Interim release 3.8.92
 
+* FIX: Links to articles that are HTML redirect stubs (e.g. Junior (suffix) in English Wikipedia) now open the target article in Restricted mode, instead of failing with File not found
+* FIX: A navigation inside the article frame can no longer re-run the article setup code and re-inject the same article
 * FIX: Mode now restored to Service Worker on next ZIM load if app has temporarily switched itself to Restricted mode
 * REGRESSION: App now auto-switches to appropriate display mode when openinig historical Wikipedia archives
 * REGRESSION: Warning about limited Zimit support now shown for zimit2 archives in Restricted mode, where it was silently skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Interim release 3.8.92
 
-* FIX: Links to articles that are HTML redirect stubs (e.g. Junior (suffix) in English Wikipedia) now open the target article in Restricted mode, instead of failing with File not found
+* FIX: Links to articles that are HTML redirect stubs now open the target article correctly in Restricted mode
 * FIX: A navigation inside the article frame can no longer re-run the article setup code and re-inject the same article
 * FIX: Mode now restored to Service Worker on next ZIM load if app has temporarily switched itself to Restricted mode
 * REGRESSION: App now auto-switches to appropriate display mode when openinig historical Wikipedia archives

--- a/www/index.html
+++ b/www/index.html
@@ -112,6 +112,7 @@
                                 <li>[New] Setting in Configuration &gt; Display settings to emulate the title bar</li>
                                 <li>[New] In-app library can now browse the whole ZIM catalogue (including uncategorized archives), with a filter textbox for searching</li>
                                 <li>[New] Fix non-responsive links that are formatted as headings in Zimit archives</li>
+                                <li>[New] Redirects via HTML meta refresh are now properly handled in Restricted Mode</li>
                                 <li>[3.8.8] Fast, resumable downloads of ZIM archives over BitTorrent directly in-app (Electron only)</li>
                                 <li>[3.8.8] Optionally seed a downloaded archive while the app remains open to help the community</li>
                                 <li>[3.8.8] More reliable ZIM download library with richer descriptions, now using the Kiwix catalogue service (OPDS)</li>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6471,9 +6471,8 @@ function handleClickOnReplayLink (ev, anchor) {
                         // If the document is in fact an html redirect, we need to follow it first till we get the underlying PDF document
                         if (/\bx?html\b/.test(mimetype)) {
                             appstate.selectedArchive.readUtf8File(dirEntry, function (fileDirEntry, data) {
-                                var redirectURL = data.match(/<meta[^>]*http-equiv="refresh"[^>]*content="[^;]*;url='?([^"']+)/i);
+                                var redirectURL = getMetaRedirectUrl(data);
                                 if (redirectURL) {
-                                    redirectURL = redirectURL[1];
                                     var contentUrl = pseudoNamespace + redirectURL.replace(/^[^/]+\/\//, '');
                                     return readAndDownloadBinaryContent(contentUrl);
                                 } else {
@@ -6916,8 +6915,50 @@ var regexpDownloadLinks = /^.*?\.epub([?#]|$)|^.*?\.pdf([?#]|$)|^.*?\.odt([?#]|$
 // This matches the data-kiwixurl of all <link> tags containing rel="stylesheet" or "...icon" in raw HTML unless commented out
 var regexpSheetHref = /(<link\s+(?=[^>]*rel\s*=\s*["'](?:stylesheet|[^"']*icon))[^>]*(?:href|data-kiwixurl)\s*=\s*["'])([^"']+)(["'][^>]*>)(?!\s*--\s*>)/ig;
 
+// A regex to find an HTML redirect stub, i.e. <meta http-equiv="refresh" content="0;url=...">, capturing the content
+// attribute's value in whichever group matches the way it is quoted. The lookahead allows the two attributes to appear
+// in either order
+var regexpMetaRedirect = /<meta\b(?=[^>]*\bhttp-equiv\s*=\s*["']?refresh\b)[^>]*\bcontent\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s">]+))/i;
+// A regex to match the HTML character references that may appear in an attribute value
+var regexpHtmlEntities = /&(?:#(\d+)|#[xX]([\da-fA-F]+)|(amp|apos|quot|lt|gt));/g;
+
 // A string to hold any anchor parameter in clicked ZIM URLs (as we must strip these to find the article in the ZIM)
 var anchorParameter;
+// Counts consecutive HTML redirects we have followed, so that a circular chain of redirect stubs cannot loop forever
+var htmlRedirectHops = 0;
+
+/**
+ * Decodes the HTML character references in the given string, as a browser would do before acting on an attribute value
+ * DEV: We deliberately decode with a regex rather than with innerHTML, because the string comes from ZIM content, which
+ * we cannot assume to be trustworthy, and assigning it to innerHTML could cause embedded markup to be parsed
+ *
+ * @param {String} str The string to decode
+ * @returns {String} The decoded string
+ */
+function decodeHtmlEntities (str) {
+    var namedEntities = { amp: '&', apos: "'", quot: '"', lt: '<', gt: '>' };
+    return str.replace(regexpHtmlEntities, function (match, decimal, hex, name) {
+        return name ? namedEntities[name] : String.fromCharCode(parseInt(decimal || hex, decimal ? 10 : 16));
+    });
+}
+
+/**
+ * Extracts the target URL from an HTML redirect stub, i.e. an article whose only content is a meta refresh directive
+ * pointing at the real article
+ *
+ * @param {String} html The HTML of the article to test for a redirect
+ * @returns {String|null} The URL the article redirects to, or null if it does not declare one
+ */
+function getMetaRedirectUrl (html) {
+    var meta = html.match(regexpMetaRedirect);
+    if (!meta) return null;
+    // Only one of the three alternatives can have matched, according to how the attribute value was quoted. We decode
+    // before extracting the URL, so that any escaped quote delimiters are stripped with the literal ones below
+    var content = decodeHtmlEntities(meta[1] || meta[2] || meta[3] || '');
+    var url = content.match(/;\s*url\s*=\s*(.+)$/i);
+    // A refresh directive with no URL simply reloads the document, so it is not a redirect
+    return url ? url[1].replace(/^["']+|["']+$/g, '').trim() : null;
+}
 
 params.containsMathTexRaw = false;
 params.containsMathTex = false;
@@ -7007,6 +7048,29 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
         // .replace(/[^/]+/g, function(m) {
         //     return encodeURIComponent(m);
         // });
+
+    // Handle HTML redirect stubs, i.e. articles whose only content is a <meta http-equiv="refresh"> pointing at the real
+    // article. In Restricted mode the iframe document is article.html, so the URL in the meta is relative to the app, not
+    // to the ZIM: if we let the browser follow it, the iframe navigates out of the app and we get a 404. Instead we
+    // neutralize the refresh and resolve the target to a ZIM URL ourselves, exactly as we do for a clicked link. In
+    // Service Worker mode the iframe URL is the ZIM path, so the same relative URL resolves correctly and the refresh is
+    // left to work natively [kiwix-js #1405, kiwix-js-pwa #931]
+    if (params.contentInjectionMode === 'jquery') {
+        var metaRedirectUrl = getMetaRedirectUrl(htmlArticle);
+        // Neutralize the refresh unconditionally: if we cannot resolve the target below, the browser must not follow it either
+        htmlArticle = htmlArticle.replace(/(<meta\b[^>]*?)http-equiv(\s*=\s*["']?refresh)/ig, '$1data-kiwix-refresh$2');
+        // We exclude Zimit archives (of either generation), whose URLs need the dedicated transformations in
+        // parseAnchorsJQuery below: for those we simply display the stub, and the user can click the link it contains
+        if (metaRedirectUrl && params.zimType === 'open' && htmlRedirectHops < 5) {
+            htmlRedirectHops++;
+            anchorParameter = metaRedirectUrl.match(/#([^#;]+)$/);
+            anchorParameter = anchorParameter ? anchorParameter[1] : '';
+            // NB deriveZimUrlFromRelativeUrl strips any anchor and returns a decoded URL, which is what goToArticle expects
+            return goToArticle(uiUtil.deriveZimUrlFromRelativeUrl(metaRedirectUrl, params.baseURL));
+        }
+        // We are displaying a real article, so reset the redirect counter
+        htmlRedirectHops = 0;
+    }
 
     // Since page has been successfully loaded, store it in the browser history
     if (params.contentInjectionMode === 'jquery') pushBrowserHistoryState(dirEntry.namespace + '/' + dirEntry.url);
@@ -7497,6 +7561,10 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
 
         // Code below will run after we have written the new article to the articleContainer
         var articleLoaded = function () {
+            // Clear the handler immediately: it is only ever intended to fire for the article we are injecting below, but
+            // any subsequent navigation of the iframe (e.g. by a meta refresh in an HTML redirect stub) would otherwise
+            // re-fire it and re-inject the same article, looping indefinitely [kiwix-js-pwa #931]
+            if (appstate.target === 'iframe') articleContainer.onload = function () {};
             if (params.contentInjectionMode === 'serviceworker') return;
             // Set a global error handler for articleWindow
             articleWindow.onerror = function (msg, url, line, col, error) {
@@ -8367,6 +8435,8 @@ function goToArticle (path, download, contentType, pathEnc) {
     appstate.selectedArchive.getDirEntryByPath(path).then(function (dirEntry) {
         var mimetype = contentType || dirEntry ? dirEntry.getMimetype() : '';
         if (dirEntry === null || dirEntry === undefined) {
+            // We did not reach an article, so any chain of HTML redirects ends here [kiwix-js-pwa #931]
+            htmlRedirectHops = 0;
             uiUtil.clearSpinner();
             console.error('Article with title ' + path + ' not found in the archive');
             if (params.zimType === 'zimit') {
@@ -8385,6 +8455,8 @@ function goToArticle (path, download, contentType, pathEnc) {
                 uiUtil.systemAlert('<p>Sorry, but we couldn\'t find the article:</p><p><i>' + path + '</i></p><p>in this archive!</p>');
             }
         } else if (download || /\/(epub|pdf|zip|.*opendocument|.*officedocument|tiff|mp4|webm|mpeg|octet-stream)\b/i.test(mimetype)) {
+            // We are opening or downloading a file rather than displaying an article, so any chain of HTML redirects ends here
+            htmlRedirectHops = 0;
             // PDFs can be treated as a special case, as they can be displayed directly in a browser window or tab in most browsers (but not UWP)
             if (!/UWP/.test(params.appType) && params.contentInjectionMode === 'serviceworker' && (/\/pdf\b/.test(mimetype) || /\.pdf([?#]|$)/i.test(dirEntry.url))) {
                 window.open(document.location.pathname.replace(/[^/]+$/, '') + appstate.selectedArchive.file.name + '/' + pathForServiceWorker,
@@ -8407,6 +8479,7 @@ function goToArticle (path, download, contentType, pathEnc) {
             readArticle(dirEntry);
         }
     }).catch(function (e) {
+        htmlRedirectHops = 0;
         console.error('Error reading article with title ' + path, e);
         if (params.appIsLaunching) goToMainArticle();
         // Line below prevents bootloop


### PR DESCRIPTION
Fixes #931. Ports [kiwix/kiwix-js#1475](https://github.com/kiwix/kiwix-js/pull/1475), which fixes kiwix/kiwix-js#1405.

## The problem

Some articles are HTML redirect stubs whose only content is a meta refresh pointing at the real article, e.g. `Junior_(suffix)` in the full English Wikipedia ZIM:

```html
<meta http-equiv="refresh" content="0;URL='./Name_suffix#Generational_titles'" />
```

In Restricted mode the iframe document is `article.html`, so `./Name_suffix` resolves to `www/Name_suffix`: the browser follows the refresh straight out of the app. In Service Worker mode the iframe URL is the ZIM path, so the same relative URL resolves correctly and the redirect already works natively.

Two browser behaviours, verified upstream, constrain the fix: the refresh **does** fire even though we inject the article with `innerHTML`, and removing the `<meta>` from the DOM *after* injection does **not** cancel the scheduled navigation. So it has to be handled on the HTML string, before injection.

## The fix

In `displayArticleContentInContainer`, gated on Restricted mode (unlike upstream, this function is reached in both modes here, so Service Worker mode stays untouched):

* Neutralize the refresh unconditionally by renaming its `http-equiv` attribute, so the browser can never follow it.
* Resolve the target to a ZIM URL and load it ourselves, reusing the same `anchorParameter` + `deriveZimUrlFromRelativeUrl` + `goToArticle` path as a clicked link, so any anchor in the target is honoured.

Safeguards:

* A hop counter bounds the chain, so circular stubs cannot loop forever. On giving up we display the now-inert stub, whose link is still clickable. The counter resets on every terminal outcome of `goToArticle`: an article displayed, a file opened or downloaded, a target not found, or a read error. The download branch matters because redirect-stub-to-PDF is a real pattern — it is exactly what `handleClickOnReplayLink` already caters for.
* Zimit archives of either generation (`zimit` and `zimit2`) are excluded from redirect-*following*, though they still get the neutralization, because their URLs need the dedicated transformations in `parseAnchorsJQuery`. It is also a deliberate safety measure: those transformed files are a delicate approximation of what ReplayWorker does in Service Worker mode, they have historically produced hard-to-trace redirects originating from iframes embedded within the article, and Zimit archives can contain almost any wild code, whereas OpenZIM archives are tightly controlled.

Target extraction is factored out of `handleClickOnReplayLink`, which uses the same pattern to follow HTML redirects to PDFs, into `getMetaRedirectUrl()`. It accepts the two attributes in either order, tolerates double-quoted, single-quoted and unquoted `content` values, and decodes HTML character references before parsing the URL — not only escaped quote delimiters, but entities *within* the URL: for a title like `Bein'_Green`, an encoded `&#39;` would otherwise leave a `#` that `deriveZimUrlFromRelativeUrl` reads as a fragment delimiter. Decoding uses a bounded regex rather than `innerHTML`, since the string comes from ZIM content.

## The downstream-only bug fixed alongside

`articleLoaded` never cleared `articleContainer.onload`, unlike the equivalent handler upstream, which clears it as the first statement of the handler. **Any** navigation of the iframe therefore re-fired it and re-injected the same `htmlArticle`. With a redirect stub this loops forever in Chrome; in Edge the navigation is aborted so `load` never fires and it stops after one silent attempt, which is why this app *appeared* to suppress meta refresh. It never did. It is a latent re-entrancy bug affecting any iframe navigation, not just redirect stubs, hence fixing it here rather than in a PR of its own.

## Testing

* `eslint` clean (3 pre-existing warnings, none in the new code); unit tests 50/50.
* Extraction checked against 20 cases in a standalone harness: the reported stub, escaped and hex-escaped quote delimiters, `&apos;` delimiters, unquoted `content`, reversed attribute order, single-quoted and uppercase forms, entities inside the URL, `&amp;` in a querystring, stray whitespace, a preserved anchor, a non-zero delay, the full stub document, and a document where the injected CSP meta precedes the refresh; plus four negative cases (a refresh with no URL, the injected CSP meta, a charset meta, and an article with no meta) that correctly return nothing. Neutralization checked against all four quoting forms, and confirmed to leave the injected CSP meta untouched.
* Manually tested extensively across browsers, with no regressions found, including on real IE11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

