### PR TITLE
Fix narrow-screen sizing classes for footer buttons and OPFS (#930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Interim release 3.8.92
 
+* FIX: The ToC and Top buttons in the bottom navigation bar now resize correctly on narrow screens
+
 * FIX: Dropped ZIM files now load in contexts where the browser blocks the File System Access API, by falling back to the legacy file drop
 * FIX: Dropping a folder that the browser will not let the app read no longer voids the folder already picked
 * FIX: Links to articles that are HTML redirect stubs now open the target article correctly in Restricted mode

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -106,8 +106,11 @@ label {
 }
 
 #navigationButtons .dropup {
-    flex: 0 0 auto;
     position: relative;
+}
+
+#navigationButtons .dropup .btn {
+    width: 100%;
 }
 
 /* Position ToC dropdown above the button */

--- a/www/index.html
+++ b/www/index.html
@@ -1536,8 +1536,8 @@
                     <a class="btn btn-outline-secondary col-1" id="btnForward" title="Forward"><i class="fas fa-arrow-circle-right"></i></a>
                     <a class="btn btn-outline-secondary col-1" style="display:none;" id="btnRandomArticleAlt" title="Random Article"><i class="fas fa-random"></i></a>
                     <a class="btn btn-outline-secondary col-1" style="display:none;" id="btnToggleThemeAlt" title="Switch between light and dark modes"><i class="fas fa-adjust"></i></a>
-                    <div class="dropup">
-                        <a href="#" class="btn btn-outline-secondary dropdown-toggle col-4" role="button" id="dropup" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <div class="dropup col-4" id="dropupContainer">
+                        <a href="#" class="btn btn-outline-secondary dropdown-toggle" role="button" id="dropup" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <b>&nbsp;ToC&nbsp;</b>
                             <span class="caret"></span>
                         </a>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -159,18 +159,20 @@ function resizeIFrame (reload) {
         ToCList.style.marginLeft = ~~(window.innerWidth / 2) - ~~(window.innerWidth * 0.16) + 'px';
     }
     if (window.outerWidth <= 470) {
-        document.getElementById('dropup').classList.remove('col-xs-4');
-        document.getElementById('dropup').classList.add('col-xs-3');
+        document.getElementById('dropup').classList.remove('col-4');
+        document.getElementById('dropup').classList.add('col-3');
         if (window.outerWidth <= 360) {
-            document.getElementById('btnTop').classList.remove('col-xs-2');
-            document.getElementById('btnTop').classList.add('col-xs-1');
+            document.getElementById('btnTop').classList.remove('col-2');
+            document.getElementById('btnTop').classList.add('col-1');
         } else {
-            document.getElementById('btnTop').classList.remove('col-xs-1');
-            document.getElementById('btnTop').classList.add('col-xs-2');
+            document.getElementById('btnTop').classList.remove('col-1');
+            document.getElementById('btnTop').classList.add('col-2');
         }
     } else {
-        document.getElementById('dropup').classList.remove('col-xs-3');
-        document.getElementById('dropup').classList.add('col-xs-4');
+        document.getElementById('dropup').classList.remove('col-3');
+        document.getElementById('dropup').classList.add('col-4');
+        document.getElementById('btnTop').classList.remove('col-1');
+        document.getElementById('btnTop').classList.add('col-2');
     }
     if (settingsStore.getItem('reloadDispatched') === 'true') {
         setTimeout(function () {
@@ -1794,15 +1796,15 @@ function setOPFSUI () {
         useOPFS.checked = true;
         archiveFiles.style.display = 'none';
         archiveFilesLabel.style.display = 'none';
-        archiveFileLabel.classList.remove('col-xs-6');
-        archiveFileLabel.classList.add('col-xs-12');
+        archiveFileLabel.classList.remove('col-6');
+        archiveFileLabel.classList.add('col-12');
         archiveFileLabel.innerHTML = '<p><b>Select file(s) to add to OPFS</b>:</p>';
         archiveFile.value = 'Add file(s)';
         archiveFile.title = 'Select a single file or multiple files to add to the Origin Private File System. In total, they must not exceed the estimated quota displayed in the OPFS quota panel.';
-        archiveFileCol.classList.remove('col-xs-6');
-        archiveFileCol.classList.add('col-xs-5');
-        archiveFilesCol.classList.remove('col-xs-6');
-        archiveFilesCol.classList.add('col-xs-7');
+        archiveFileCol.classList.remove('col-6');
+        archiveFileCol.classList.add('col-5');
+        archiveFilesCol.classList.remove('col-6');
+        archiveFilesCol.classList.add('col-7');
         archiveList.style.background = determinedTheme === 'dark' ? 'darkslategray' : 'lightcyan';
         OPFSQuota.style.display = '';
         btnDeleteOPFSEntry.style.display = '';
@@ -1810,23 +1812,23 @@ function setOPFSUI () {
         cache.populateOPFSStorageQuota();
     } else {
         useOPFS.checked = false;
-        archiveFileCol.classList.remove('col-xs-5');
-        archiveFileCol.classList.add('col-xs-6');
-        archiveFilesCol.classList.remove('col-xs-7');
-        archiveFilesCol.classList.add('col-xs-6');
+        archiveFileCol.classList.remove('col-5');
+        archiveFileCol.classList.add('col-6');
+        archiveFilesCol.classList.remove('col-7');
+        archiveFilesCol.classList.add('col-6');
         archiveList.style.background = '';
         if (typeof Windows === 'undefined' && typeof window.showOpenFilePicker !== 'function' && !window.dialog && !params.webkitdirectory) {
             archiveFileLabel.innerHTML = '<p><b>Pick ZIM archive(s)</b>:</p>';
-            archiveFileLabel.classList.remove('col-xs-6');
-            archiveFileLabel.classList.add('col-xs-12');
+            archiveFileLabel.classList.remove('col-6');
+            archiveFileLabel.classList.add('col-12');
             archiveFile.title = 'Select one or more files you wish to access during this session from your device\'s storage. You may load as many files as you wish, and they will be added to the selection list above.';
             archiveFile.value = 'Select file(s)';
         } else {
             archiveFiles.style.display = '';
             archiveFilesLabel.style.display = '';
             archiveFileLabel.innerHTML = '<p><b>Pick a single unsplit archive</b>:</p>';
-            archiveFileLabel.classList.remove('col-xs-12');
-            archiveFileLabel.classList.add('col-xs-6');
+            archiveFileLabel.classList.remove('col-12');
+            archiveFileLabel.classList.add('col-6');
             archiveFile.title = 'Select a single file from your device\'s storage. For split or multiple files, place the files in a directory and use the "Select folder" button instead.';
             archiveFile.value = 'Select file';
         }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -159,8 +159,8 @@ function resizeIFrame (reload) {
         ToCList.style.marginLeft = ~~(window.innerWidth / 2) - ~~(window.innerWidth * 0.16) + 'px';
     }
     if (window.outerWidth <= 470) {
-        document.getElementById('dropup').classList.remove('col-4');
-        document.getElementById('dropup').classList.add('col-3');
+        document.getElementById('dropupContainer').classList.remove('col-4');
+        document.getElementById('dropupContainer').classList.add('col-3');
         if (window.outerWidth <= 360) {
             document.getElementById('btnTop').classList.remove('col-2');
             document.getElementById('btnTop').classList.add('col-1');
@@ -169,8 +169,8 @@ function resizeIFrame (reload) {
             document.getElementById('btnTop').classList.add('col-2');
         }
     } else {
-        document.getElementById('dropup').classList.remove('col-3');
-        document.getElementById('dropup').classList.add('col-4');
+        document.getElementById('dropupContainer').classList.remove('col-3');
+        document.getElementById('dropupContainer').classList.add('col-4');
         document.getElementById('btnTop').classList.remove('col-1');
         document.getElementById('btnTop').classList.add('col-2');
     }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -156,7 +156,6 @@ function resizeIFrame (reload) {
     var ToCList = document.getElementById('ToCList');
     if (typeof ToCList !== 'undefined') {
         ToCList.style.maxHeight = ~~(window.innerHeight * 0.75) + 'px';
-        ToCList.style.marginLeft = ~~(window.innerWidth / 2) - ~~(window.innerWidth * 0.16) + 'px';
     }
     if (window.outerWidth <= 470) {
         document.getElementById('dropupContainer').classList.remove('col-4');
@@ -8302,7 +8301,6 @@ function setupTableOfContents () {
     });
     var ToCList = document.getElementById('ToCList');
     ToCList.style.maxHeight = ~~(window.innerHeight * 0.75) + 'px';
-    ToCList.style.marginLeft = ~~(window.innerWidth / 2) - ~~(window.innerWidth * 0.16) + 'px';
     ToCList.innerHTML = dropupHtml;
     Array.prototype.slice.call(ToCList.getElementsByTagName('a')).forEach(function (listElement) {
         listElement.addEventListener('click', function () {


### PR DESCRIPTION
Fixes #930

### Problem
Following the Bootstrap 4 migration, dynamic class manipulation in `www/js/app.js` still referenced Bootstrap 3 `col-xs-*` classes. Because Bootstrap 4 dropped the `-xs` infix, the `classList.remove()` and `classList.add()` calls were inert, preventing the Table of Contents dropup (`#dropup`) and Top button (`#btnTop`) from narrowing on small screens (<= 470px and <= 360px). Similar inert `col-xs-*` classes remained in the OPFS settings toggle.

### Solution
- Updated `resizeIFrame()` in `www/js/app.js` to toggle `col-4`/`col-3` on `#dropup` and `col-2`/`col-1` on `#btnTop`.
- Ensured `#btnTop` resets back to `col-2` when resizing to viewports > 470px.
- Updated `setOPFSUI()` to toggle `col-6`/`col-12` on `archiveFileLabel` and `col-5`/`col-6`/`col-7` on `archiveFileCol` and `archiveFilesCol`.

### Testing
- Ran ESLint on `www/js/app.js` (0 errors).
- Built unminified bundle via `npm run build-src` with Rollup/Babel.
- Swept repository to verify no remaining `col-xs-*` classes.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
