### PR TITLE
Fix Bootstrap 3 glyphicon leftovers and fullscreen icon click target (#934)

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -502,6 +502,7 @@ div:not(.card.border-success .card-body):not(.alert-message) {
     height: 50px;
 }
 
+.fas.spinning,
 .fa.spinning {
     color: white;
     -webkit-animation: spin 1s linear infinite;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1595,7 +1595,7 @@ archiveFilesLegacy.addEventListener('change', function (files) {
             if (!confirmed) return;
             // User has chosen a file or files to store in the Origin Private File System
             // This operation can take a long time, so show opsPanel
-            uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Importing files to OPFS...', true);
+            uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Please wait:</b> Importing files to OPFS...', true);
             return cache.importOPFSEntries(filesArray).then(function () {
                 uiUtil.systemAlert('<p>The selected files were successfully added to the OPFS!</p><p><b>We will now reload the app, so that the file(s) can be accessed at full speed.</b></p>')
                 .then(function () {
@@ -2292,7 +2292,7 @@ var refreshFullScreen = function (evt) {
     if (/archiveFilesLegacy|lockDisplayOrientationDrop/.test(evt.target.id)) return;
     // Don't react when picking archive or directory with the File System Access API (because entering fullscreen blocks the permissions prompt)
     if (evt.target.parentElement && evt.target.parentElement.id === 'archiveList' && window.showDirectoryPicker) return;
-    if (params.lockDisplayOrientation && (evt.target.id === 'btnAbout' || /glyphicon-(resize-small|fullscreen)/.test(evt.target.className))) {
+    if (params.lockDisplayOrientation && (evt.target.id === 'btnAbout' || /fa-(compress|expand)/.test(evt.target.className) || (evt.target.closest && evt.target.closest('#btnAbout')))) {
         if (uiUtil.appIsFullScreen()) {
             // Cancel fullscreen mode
             uiUtil.lockDisplayOrientation().then(function () {
@@ -2333,7 +2333,7 @@ document.getElementById('lockDisplayOrientationDrop').addEventListener('change',
                 if (rtn === 'click') {
                     uiUtil.systemAlert((!params.PWAInstalled && /iOS/.test(params.appType)
                         ? '<p>In Safari on iOS, consider adding this app to your homescreen (Share --&gt Add to Home), which will give a better experience than full-screen mode.</p>' : '') +
-                         '<p>Please click the &nbsp;<span class="glyphicon glyphicon-fullscreen"></span>&nbsp; button top-right to enter full-screen mode.</p>'
+                         '<p>Please click the &nbsp;<i class="fas fa-expand"></i>&nbsp; button top-right to enter full-screen mode.</p>'
                     );
                 }
             }

--- a/www/js/lib/cache.js
+++ b/www/js/lib/cache.js
@@ -812,9 +812,9 @@ function importOPFSEntries (files) {
     return Promise.all(files.map(function (file) {
         return params.pickedFolder.getFileHandle(file.name, { create: true }).then(function (fileHandle) {
             return fileHandle.createWritable().then(function (writer) {
-                uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Importing ' + file.name + '...', true);
+                uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Please wait:</b> Importing ' + file.name + '...', true);
                 return writer.write(file).then(function () {
-                    uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Imported ' + file.name + '...', true);
+                    uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Please wait:</b> Imported ' + file.name + '...', true);
                     return writer.close();
                 });
             });

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1478,7 +1478,7 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
                     var archiveName = e.target.href.replace(/^.*\/([^/]+)$/, '$1');
                     var downloadArchiveWithFSA = function () {
                         downloadSize = megabytes;
-                        uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Downloading archive... 0%', true);
+                        uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Please wait:</b> Downloading archive... 0%', true);
                         return cache.downloadArchiveToPickedFolder(archiveName, archiveUrl, reportDownloadProgress).then(function () {
                             return uiUtil.systemAlert('<p>The archive ' + archiveName + ' has been downloaded to your device.</p>' +
                             (params.useOPFS ? '<p><b>Reloading to activate new ZIM...</b></p>' : ''), 'Download complete').then(function () {
@@ -2051,7 +2051,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
     // Remembered now (before the name is known) so that even a crash during the initial fetch
     // or hash-check of on-disk data is still offered for resumption on the next launch
     persistActiveTorrent(torrentUrl, savePath);
-    uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Starting BitTorrent download...', true);
+    uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Please wait:</b> Starting BitTorrent download...', true);
     torrentClient.start(torrentUrl, savePath, {
         onProgress: function (s) {
             if (s.verifying) {
@@ -2141,7 +2141,7 @@ function reportDownloadProgress (received, total) {
             var percentageData = Math.floor(dataMB / downloadSize * 100);
             if (percentageData > percentageComplete) {
                 percentageComplete = percentageData;
-                uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Do not quit app:</b> Downloading archive... ' + percentageComplete + '% (' + formattedData + ')', true);
+                uiUtil.pollOpsPanel('<i class="fas fa-sync-alt fa-spin"></i>&emsp;<b>Do not quit app:</b> Downloading archive... ' + percentageComplete + '% (' + formattedData + ')', true);
             }
         }
     }


### PR DESCRIPTION
Fixes #934

### Problem
Following the Bootstrap 4 / FontAwesome migration (`d7132d55`), residual Bootstrap 3 `glyphicon` references caused subtle click handler and UI display regressions:
1. **Fullscreen Toggle on Icon Click**: In `refreshFullScreen` (`www/js/app.js`), clicking the top-right button's icon (`<i class="fas fa-expand"></i>` / `<i class="fas fa-compress"></i>`) was inert because `evt.target` was the `<i>` element, and the check `/glyphicon-(resize-small|fullscreen)/.test(evt.target.className)` never matched FontAwesome classes.
2. **Missing System Alert Icon**: In `lockDisplayOrientationDrop`'s change handler (`www/js/app.js`), the alert prompt contained `<span class="glyphicon glyphicon-fullscreen"></span>`, rendering an invisible gap.
3. **Broken Spinning Progress Indicators**: OPFS import and in-app download progress banners (`www/js/app.js`, `www/js/lib/cache.js`, `www/js/lib/kiwixServe.js`) used `<span class="glyphicon glyphicon-refresh spinning"></span>`, which rendered a blank space instead of a spinning refresh icon.

---

### Solution
1. **Click Target Fix**: Updated `refreshFullScreen` in `www/js/app.js` to match FontAwesome classes `/fa-(compress|expand)/.test(evt.target.className)` and support `(evt.target.closest && evt.target.closest('#btnAbout'))`.
2. **System Alert Prompt**: Replaced the legacy glyphicon markup with `<i class="fas fa-expand"></i>`.
3. **Spinning Indicators**: Replaced legacy `glyphicon-refresh spinning` with `<i class="fas fa-sync-alt fa-spin"></i>` across OPFS imports and in-app download handlers (`kiwixServe.js`, `cache.js`, `app.js`).
4. **CSS Animation**: Added `.fas.spinning` to `www/css/app.css` alongside `.fa.spinning`.

---

### Verification
- Tested fullscreen toggle via clicking `#btnAbout` as well as its inner `<i>` icon glyph when `lockDisplayOrientation` is active.
- Verified all download and OPFS progress banners display the spinning FontAwesome icon.
- Verified that zero `glyphicon` references remain in active JS application code.
- Successfully built project bundle via `npm run build-src` (`dist/www/js/bundle.js`).

---
Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
