### PR TITLE
Fix brittle regex JSON parsing in updater.js (#936)

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/overrideParams.test.cjs",
+    "test": "node test/overrideParams.test.cjs && node test/updater.test.cjs",
     "serve": "vite",
     "preview": "del-cli dist && npm run build-src && vite preview",
     "prebuild": "del-cli dist",

--- a/test/fixtures/github-releases-sample.json
+++ b/test/fixtures/github-releases-sample.json
@@ -1,0 +1,78 @@
+[
+  {
+    "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/1",
+    "tag_name": "v4.0.0-E",
+    "target_commitish": "main",
+    "name": "v4.0.0-E",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2026-08-01T10:00:00Z",
+    "published_at": "2026-08-01T10:05:00Z",
+    "html_url": "https://github.com/kiwix/kiwix-js-pwa/releases/tag/v4.0.0-E",
+    "body": "See the changelog for details. Download links are also mirrored at https://download.kiwix.org/release/kiwix-js-pwa/ for convenience.",
+    "assets": [
+      {
+        "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/assets/1001",
+        "id": 1001,
+        "name": "source.zip",
+        "content_type": "application/zip",
+        "state": "uploaded",
+        "size": 5242880,
+        "uploader": {
+          "login": "bhuvan-somisetty",
+          "id": 123456,
+          "avatar_url": "https://avatars.githubusercontent.com/u/123456?v=4",
+          "html_url": "https://github.com/bhuvan-somisetty",
+          "type": "User"
+        },
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/source.zip"
+      },
+      {
+        "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/assets/1002",
+        "id": 1002,
+        "name": "kiwix-electron-4.0.0-E.exe",
+        "content_type": "application/x-msdownload",
+        "state": "uploaded",
+        "size": 104857600,
+        "uploader": {
+          "login": "bhuvan-somisetty",
+          "id": 123456,
+          "avatar_url": "https://avatars.githubusercontent.com/u/123456?v=4",
+          "html_url": "https://github.com/bhuvan-somisetty",
+          "type": "User"
+        },
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E.exe"
+      }
+    ]
+  },
+  {
+    "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/2",
+    "tag_name": "v3.9.0-E",
+    "target_commitish": "main",
+    "name": "v3.9.0-E",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2026-05-01T10:00:00Z",
+    "published_at": "2026-05-01T10:05:00Z",
+    "html_url": "https://github.com/kiwix/kiwix-js-pwa/releases/tag/v3.9.0-E",
+    "body": "Minor fixes.",
+    "assets": [
+      {
+        "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/assets/902",
+        "id": 902,
+        "name": "kiwix-electron-3.9.0-E.exe",
+        "content_type": "application/x-msdownload",
+        "state": "uploaded",
+        "size": 98765432,
+        "uploader": {
+          "login": "bhuvan-somisetty",
+          "id": 123456,
+          "avatar_url": "https://avatars.githubusercontent.com/u/123456?v=4",
+          "html_url": "https://github.com/bhuvan-somisetty",
+          "type": "User"
+        },
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0-E/kiwix-electron-3.9.0-E.exe"
+      }
+    ]
+  }
+]

--- a/test/fixtures/github-releases-sample.json
+++ b/test/fixtures/github-releases-sample.json
@@ -30,8 +30,8 @@
       {
         "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/assets/1002",
         "id": 1002,
-        "name": "kiwix-electron-4.0.0-E.exe",
-        "content_type": "application/x-msdownload",
+        "name": "kiwix-js-electron-4.0.0-E-x64.nsis.7z",
+        "content_type": "application/x-7z-compressed",
         "state": "uploaded",
         "size": 104857600,
         "uploader": {
@@ -41,15 +41,15 @@
           "html_url": "https://github.com/bhuvan-somisetty",
           "type": "User"
         },
-        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E.exe"
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-js-electron-4.0.0-E-x64.nsis.7z"
       },
       {
-        "name": "kiwix-electron-4.0.0-E-wikivoyage.exe",
-        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E-wikivoyage.exe"
+        "name": "kiwix-js-wikivoyage-4.0.0-E-arm64.nsis.7z",
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-js-wikivoyage-4.0.0-E-arm64.nsis.7z"
       },
       {
-        "name": "kiwix-electron-4.0.0-E-wikimed.exe",
-        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E-wikimed.exe"
+        "name": "kiwix-js-wikimed-4.0.0-E-arm64.nsis.7z",
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-js-wikimed-4.0.0-E-arm64.nsis.7z"
       }
     ]
   },
@@ -68,8 +68,8 @@
       {
         "url": "https://api.github.com/repos/kiwix/kiwix-js-pwa/releases/assets/902",
         "id": 902,
-        "name": "kiwix-electron-3.9.0-E.exe",
-        "content_type": "application/x-msdownload",
+        "name": "kiwix-js-electron-3.9.0-E-x64.nsis.7z",
+        "content_type": "application/x-7z-compressed",
         "state": "uploaded",
         "size": 98765432,
         "uploader": {
@@ -79,7 +79,7 @@
           "html_url": "https://github.com/bhuvan-somisetty",
           "type": "User"
         },
-        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0-E/kiwix-electron-3.9.0-E.exe"
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0-E/kiwix-js-electron-3.9.0-E-x64.nsis.7z"
       }
     ]
   }

--- a/test/fixtures/github-releases-sample.json
+++ b/test/fixtures/github-releases-sample.json
@@ -42,6 +42,14 @@
           "type": "User"
         },
         "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E.exe"
+      },
+      {
+        "name": "kiwix-electron-4.0.0-E-wikivoyage.exe",
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E-wikivoyage.exe"
+      },
+      {
+        "name": "kiwix-electron-4.0.0-E-wikimed.exe",
+        "browser_download_url": "https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E-wikimed.exe"
       }
     ]
   },

--- a/test/updater.test.cjs
+++ b/test/updater.test.cjs
@@ -65,21 +65,17 @@ function run (mockResponse, context) {
  * rejecting) if the API can't be reached, so a lack of network access skips the check instead
  * of failing the suite.
  *
- * GitHub varies the JSON formatting on the Accept header (note `Vary: Accept` on the response):
- * send one and you get pretty-printed JSON, one field per line; omit it and you get everything
- * minified onto a single line. https.get sends no Accept header by default, so with
- * withAcceptHeader left false this exercises the minified path - the shape that actually breaks
- * the old greedy-wildcard regex. Pass withAcceptHeader: true to fetch the pretty-printed shape
- * instead, which is what the app itself receives (uiUtil.XHR uses XMLHttpRequest, and browsers
- * add an `Accept: * / *` wildcard header to every request automatically).
+ * GitHub serves both a pretty-printed (one field per line) and a fully minified shape of the
+ * identical content, unpredictably, for identical requests a few minutes apart - it is not
+ * selected by the Accept header, HTTP version or User-Agent. So this fetches once and the
+ * caller derives the other shape locally with JSON.parse/JSON.stringify rather than relying on
+ * two live fetches to land on different shapes.
  *
- * @param {Boolean} [withAcceptHeader] Send an explicit Accept header to request the pretty-printed shape
  * @returns {Promise<String|null>} The raw response text, or null if it could not be fetched
  */
-function fetchLiveReleases (withAcceptHeader) {
+function fetchLiveReleases () {
     return new Promise(function (resolve) {
         var headers = { 'User-Agent': 'kiwix-js-pwa-updater-test' };
-        if (withAcceptHeader) headers.Accept = '*/*';
         var req = https.get('https://api.github.com/repos/kiwix/kiwix-js-pwa/releases', {
             headers: headers,
             timeout: 5000
@@ -207,6 +203,35 @@ async function runTests () {
     check('Detects highest version on a realistically pretty-printed response', prettyRes.updateTag === 'v4.0.0-E');
     check('Download URL is not corrupted with JSON punctuation from neighbouring fields', /^https:\/\/[^\s"{}[\]]+$/.test(prettyRes.updatedReleases[0] || ''));
 
+    section('BaseApp packaging filter (realistic asset naming, from fixture)');
+    // Real flavour assets (e.g. kiwix-js-wikivoyage-3.8.2-E-arm64.nsis.7z) don't contain
+    // "electron"/"windows"/"kiwixwebapp_", so they must not be picked up by a default-build
+    // check, and a flavour check must only pick up its own flavour's asset.
+    const wikivoyageFixtureRes = await run(prettyPrintedPayload, { appVersion: '3.8.92-E', packagedFile: 'wikivoyage_en_all_maxi.zim' });
+    check('Wikivoyage packagedFile only captures the wikivoyage asset from the fixture',
+        wikivoyageFixtureRes.updatedReleases.length === 1 && /wikivoyage/.test(wikivoyageFixtureRes.updatedReleases[0]));
+
+    const wikimedFixtureRes = await run(prettyPrintedPayload, { appVersion: '3.8.92-E', packagedFile: 'wikimed_en_all_maxi.zim' });
+    check('WikiMed packagedFile only captures the wikimed asset from the fixture',
+        wikimedFixtureRes.updatedReleases.length === 1 && /wikimed/.test(wikimedFixtureRes.updatedReleases[0]));
+
+    check('Default (non-flavour) check on the fixture does not pick up flavour assets',
+        prettyRes.updatedReleases.every(function (url) { return !/wikivoyage|wikimed/.test(url); }));
+
+    section('Minified/pretty-printed equivalence (fixture, always runs offline)');
+    // Derive both JSON shapes locally from the same parsed data, rather than depending on the
+    // network to hand back both shapes for the same content (see the live section below for why).
+    const fixtureParsed = JSON.parse(prettyPrintedPayload);
+    const fixtureAsMinified = JSON.stringify(fixtureParsed);
+    const fixtureAsPretty = JSON.stringify(fixtureParsed, null, 2) + '\n';
+    check('Derived minified fixture shape is a single line', fixtureAsMinified.split('\n').length === 1);
+    check('Derived pretty-printed fixture shape spans many lines', fixtureAsPretty.split('\n').length > 10);
+    const fixtureMinRes = await run(fixtureAsMinified, { appVersion: '3.8.92-E' });
+    const fixturePrettyRes = await run(fixtureAsPretty, { appVersion: '3.8.92-E' });
+    check('Minified and pretty-printed fixture shapes agree',
+        fixtureMinRes.updateTag === fixturePrettyRes.updateTag &&
+        JSON.stringify(fixtureMinRes.updatedReleases) === JSON.stringify(fixturePrettyRes.updatedReleases));
+
     section('Live GitHub API (skipped if offline)');
     const liveReleasesText = await fetchLiveReleases();
     if (liveReleasesText === null) {
@@ -236,17 +261,19 @@ async function runTests () {
             });
             check('Detected tag matches the newest matching release in the parsed payload',
                 !!expectedRelease && liveRes.updateTag === expectedRelease.tag_name);
-        }
 
-        // The Accept-header behaviour documented on fetchLiveReleases is exactly the assumption
-        // this fix rests on: assert the minified and pretty-printed shapes of the same live data
-        // produce identical results, as a direct test of that invariant
-        const liveReleasesTextWithAccept = await fetchLiveReleases(true);
-        if (liveReleasesTextWithAccept !== null) {
-            const liveResWithAccept = await run(liveReleasesTextWithAccept, { appVersion: '0.0.1' });
-            check('Minified (no Accept header) and pretty-printed (Accept: */*) responses agree',
-                liveResWithAccept.updateTag === liveRes.updateTag &&
-                JSON.stringify(liveResWithAccept.updatedReleases) === JSON.stringify(liveRes.updatedReleases));
+            // Derive both JSON shapes locally from this single fetch instead of relying on a
+            // second live fetch to happen to land on a different shape (see fetchLiveReleases doc)
+            const liveAsMinified = JSON.stringify(liveReleasesJson);
+            const liveAsPretty = JSON.stringify(liveReleasesJson, null, 2) + '\n';
+            check('Derived minified live shape is a single line', liveAsMinified.split('\n').length === 1);
+            check('Derived pretty-printed live shape spans many lines', liveAsPretty.split('\n').length > 10);
+
+            const liveMinRes = await run(liveAsMinified, { appVersion: '0.0.1' });
+            const livePrettyRes = await run(liveAsPretty, { appVersion: '0.0.1' });
+            check('Minified and pretty-printed shapes of the same live data agree',
+                liveMinRes.updateTag === livePrettyRes.updateTag &&
+                JSON.stringify(liveMinRes.updatedReleases) === JSON.stringify(livePrettyRes.updatedReleases));
         }
     }
 

--- a/test/updater.test.cjs
+++ b/test/updater.test.cjs
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
 
 const UPDATER_JS = path.join(__dirname, '..', 'www', 'js', 'lib', 'updater.js');
 
@@ -55,6 +56,34 @@ function run (mockResponse, context) {
                 updatedReleases: updatedReleases
             });
         });
+    });
+}
+
+/**
+ * Fetches the real releases list from the GitHub API, to check the code against the actual
+ * response shape rather than only hand-written fixtures. Resolves to null (rather than
+ * rejecting) if the API can't be reached, so a lack of network access skips the check instead
+ * of failing the suite.
+ *
+ * @returns {Promise<String|null>} The raw response text, or null if it could not be fetched
+ */
+function fetchLiveReleases () {
+    return new Promise(function (resolve) {
+        var req = https.get('https://api.github.com/repos/kiwix/kiwix-js-pwa/releases', {
+            headers: { 'User-Agent': 'kiwix-js-pwa-updater-test' },
+            timeout: 5000
+        }, function (res) {
+            if (res.statusCode !== 200) {
+                res.resume();
+                resolve(null);
+                return;
+            }
+            var data = '';
+            res.on('data', function (chunk) { data += chunk; });
+            res.on('end', function () { resolve(data); });
+        });
+        req.on('timeout', function () { req.destroy(); resolve(null); });
+        req.on('error', function () { resolve(null); });
     });
 }
 
@@ -156,6 +185,32 @@ async function runTests () {
 
     const emptyResponse = await run('', { appVersion: '3.8.0' });
     check('Handles empty response gracefully', emptyResponse.updateTag === undefined && emptyResponse.updatedReleases.length === 0);
+
+    section('Real API response shape (pretty-printed, one field per line)');
+    // GitHub's REST API pretty-prints its JSON responses with one field per line, which is
+    // what actually reaches this code in production - unlike the hand-minified fixtures above.
+    const prettyPrintedPayload = fs.readFileSync(path.join(__dirname, 'fixtures', 'github-releases-sample.json'), 'utf8');
+    const prettyRes = await run(prettyPrintedPayload, { appVersion: '3.8.92-E' });
+    check('Detects highest version on a realistically pretty-printed response', prettyRes.updateTag === 'v4.0.0-E');
+    check('Download URL is not corrupted with JSON punctuation from neighbouring fields', /^https:\/\/[^\s"{}[\]]+$/.test(prettyRes.updatedReleases[0] || ''));
+
+    section('Live GitHub API (skipped if offline)');
+    const liveReleasesText = await fetchLiveReleases();
+    if (liveReleasesText === null) {
+        console.log('  skip  Could not reach the GitHub releases API - skipping live comparison');
+    } else {
+        let liveRes;
+        let threw = false;
+        try {
+            liveRes = await run(liveReleasesText, { appVersion: '0.0.1' });
+        } catch (e) {
+            threw = true;
+        }
+        check('Parses the live API response without throwing', !threw);
+        check('Every matched download URL is well-formed and unquoted', !threw && liveRes.updatedReleases.every(function (url) {
+            return /^https:\/\/[^\s"{}[\]]+$/.test(url);
+        }));
+    }
 
     section('Consecutive invocation idempotency');
     const firstCall = await run(minifiedPayload, { appVersion: '3.8.92-E' });

--- a/test/updater.test.cjs
+++ b/test/updater.test.cjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Checks GitHub release parsing and version comparison in www/js/lib/updater.js.
+ *
+ * Usage: npm test
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const UPDATER_JS = path.join(__dirname, '..', 'www', 'js', 'lib', 'updater.js');
+
+function extractUpdaterFunctions (source) {
+    // Strip ES module import and export to evaluate inside a CommonJS sandbox
+    const transformed = source
+        .replace(/^\s*import\s+.*?;\s*$/gm, '')
+        .replace(/^\s*export\s+default\s+[\s\S]*?;\s*$/gm, '');
+
+    return transformed;
+}
+
+const updaterSource = extractUpdaterFunctions(fs.readFileSync(UPDATER_JS, 'utf8'));
+
+/**
+ * Runs updater.getLatestUpdates() against a mocked environment
+ *
+ * @param {String|Object} mockResponse The API response text (or object) to simulate
+ * @param {Object} context App configuration (appVersion, packagedFile, etc.)
+ * @returns {Promise<Object>} The resulting { updateTag, updateUrl, updatedReleases }
+ */
+function run (mockResponse, context) {
+    return new Promise(function (resolve) {
+        var params = { // eslint-disable-line no-unused-vars
+            appVersion: context.appVersion || '3.8.92-E',
+            packagedFile: context.packagedFile || '',
+            updateServer: { url: 'https://api.github.com/repos/kiwix/kiwix-js-pwa/', releases: 'releases' }
+        };
+        var uiUtil = { // eslint-disable-line no-unused-vars
+            XHR: function (url, type, callback) {
+                var text = typeof mockResponse === 'string' ? mockResponse : JSON.stringify(mockResponse);
+                callback(text, 'application/json', 200);
+            }
+        };
+
+        // Evaluate the extracted functions in sandbox scope
+        // eslint-disable-next-line no-eval
+        var getLatestUpdates = eval('(function () {\n' + updaterSource + '\nreturn getLatestUpdates;\n})()');
+
+        getLatestUpdates(function (updateTag, updateUrl, updatedReleases) {
+            resolve({
+                updateTag: updateTag,
+                updateUrl: updateUrl,
+                updatedReleases: updatedReleases
+            });
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------------------------------
+
+let failures = 0;
+let total = 0;
+
+function section (title) {
+    console.log('\n' + title);
+}
+
+function check (description, passed) {
+    total++;
+    if (passed) {
+        console.log('  ok    ' + description);
+    } else {
+        failures++;
+        console.log('  FAIL  ' + description);
+    }
+}
+
+async function runTests () {
+    section('Minified JSON handling and multi-asset parsing');
+    const minifiedPayload = JSON.stringify([
+        {
+            tag_name: 'v4.0.0-E',
+            html_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/tag/v4.0.0-E',
+            assets: [
+                { name: 'source.zip', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/source.zip' },
+                { name: 'kiwix-electron-4.0.0-E.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E.exe' }
+            ]
+        },
+        {
+            tag_name: 'v3.9.0-E',
+            html_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/tag/v3.9.0-E',
+            assets: [
+                { name: 'kiwix-electron-3.9.0-E.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0-E/kiwix-electron-3.9.0-E.exe' }
+            ]
+        }
+    ]);
+
+    let res = await run(minifiedPayload, { appVersion: '3.8.92-E' });
+    check('Detects highest version v4.0.0-E on minified JSON', res.updateTag === 'v4.0.0-E');
+    check('Download URL contains clean uncorrupted URL', res.updatedReleases[0] === 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v4.0.0-E/kiwix-electron-4.0.0-E.exe');
+    check('Collects all newer matching releases in updatedReleases list', res.updatedReleases.length === 2);
+
+    section('Channel matching logic');
+    const multiChannelPayload = [
+        {
+            tag_name: 'v3.9.5',
+            html_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/tag/v3.9.5',
+            assets: [
+                { name: 'kiwix-electron-3.9.5.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.5/kiwix-electron-3.9.5.exe' }
+            ]
+        },
+        {
+            tag_name: 'v3.9.5-E',
+            html_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/tag/v3.9.5-E',
+            assets: [
+                { name: 'kiwix-electron-3.9.5-E.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.5-E/kiwix-electron-3.9.5-E.exe' }
+            ]
+        }
+    ];
+
+    res = await run(multiChannelPayload, { appVersion: '3.8.92-E' });
+    check('Prefers channel match (-E) when same underlying version exists', res.updateTag === 'v3.9.5-E');
+
+    const nonChannelApp = await run(multiChannelPayload, { appVersion: '3.8.92' });
+    check('Non-channel client matches non-channel release', nonChannelApp.updateTag === 'v3.9.5');
+
+    section('BaseApp packaging filter');
+    const packagedReleases = [
+        {
+            tag_name: 'v3.9.0',
+            html_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/tag/v3.9.0',
+            assets: [
+                { name: 'kiwix-electron-3.9.0.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0/kiwix-electron-3.9.0.exe' },
+                { name: 'wikivoyage-setup.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0/wikivoyage-setup.exe' },
+                { name: 'wikimed-setup.exe', browser_download_url: 'https://github.com/kiwix/kiwix-js-pwa/releases/download/v3.9.0/wikimed-setup.exe' }
+            ]
+        }
+    ];
+
+    const wikivoyageRes = await run(packagedReleases, { appVersion: '3.8.0', packagedFile: 'wikivoyage_en_all.zim' });
+    check('Wikivoyage packaged app only captures wikivoyage asset', wikivoyageRes.updatedReleases.length === 1 && /wikivoyage/.test(wikivoyageRes.updatedReleases[0]));
+
+    const wikimedRes = await run(packagedReleases, { appVersion: '3.8.0', packagedFile: 'wikimed_en_all.zim' });
+    check('WikiMed packaged app only captures wikimed asset', wikimedRes.updatedReleases.length === 1 && /wikimed/.test(wikimedRes.updatedReleases[0]));
+
+    section('Up to date and malformed response handling');
+    const alreadyLatest = await run(packagedReleases, { appVersion: '3.9.0' });
+    check('Returns undefined updateTag when already on latest version', alreadyLatest.updateTag === undefined);
+
+    const malformedJson = await run('not valid json {[[', { appVersion: '3.8.0' });
+    check('Handles malformed JSON gracefully without throwing', malformedJson.updateTag === undefined && malformedJson.updatedReleases.length === 0);
+
+    const emptyResponse = await run('', { appVersion: '3.8.0' });
+    check('Handles empty response gracefully', emptyResponse.updateTag === undefined && emptyResponse.updatedReleases.length === 0);
+
+    section('Consecutive invocation idempotency');
+    const firstCall = await run(minifiedPayload, { appVersion: '3.8.92-E' });
+    const secondCall = await run(minifiedPayload, { appVersion: '3.8.92-E' });
+    check('First call detects correct update', firstCall.updateTag === 'v4.0.0-E');
+    check('Second call detects identical update without state leakage', secondCall.updateTag === 'v4.0.0-E');
+
+    if (failures > 0) {
+        console.error('\n' + failures + ' of ' + total + ' checks failed.');
+        process.exit(1);
+    } else {
+        console.log('\nAll ' + total + ' checks passed\n');
+    }
+}
+
+runTests();

--- a/test/updater.test.cjs
+++ b/test/updater.test.cjs
@@ -65,12 +65,23 @@ function run (mockResponse, context) {
  * rejecting) if the API can't be reached, so a lack of network access skips the check instead
  * of failing the suite.
  *
+ * GitHub varies the JSON formatting on the Accept header (note `Vary: Accept` on the response):
+ * send one and you get pretty-printed JSON, one field per line; omit it and you get everything
+ * minified onto a single line. https.get sends no Accept header by default, so with
+ * withAcceptHeader left false this exercises the minified path - the shape that actually breaks
+ * the old greedy-wildcard regex. Pass withAcceptHeader: true to fetch the pretty-printed shape
+ * instead, which is what the app itself receives (uiUtil.XHR uses XMLHttpRequest, and browsers
+ * add an `Accept: * / *` wildcard header to every request automatically).
+ *
+ * @param {Boolean} [withAcceptHeader] Send an explicit Accept header to request the pretty-printed shape
  * @returns {Promise<String|null>} The raw response text, or null if it could not be fetched
  */
-function fetchLiveReleases () {
+function fetchLiveReleases (withAcceptHeader) {
     return new Promise(function (resolve) {
+        var headers = { 'User-Agent': 'kiwix-js-pwa-updater-test' };
+        if (withAcceptHeader) headers.Accept = '*/*';
         var req = https.get('https://api.github.com/repos/kiwix/kiwix-js-pwa/releases', {
-            headers: { 'User-Agent': 'kiwix-js-pwa-updater-test' },
+            headers: headers,
             timeout: 5000
         }, function (res) {
             if (res.statusCode !== 200) {
@@ -78,6 +89,7 @@ function fetchLiveReleases () {
                 resolve(null);
                 return;
             }
+            res.setEncoding('utf8'); // Buffers multi-byte UTF-8 sequences split across TCP chunks
             var data = '';
             res.on('data', function (chunk) { data += chunk; });
             res.on('end', function () { resolve(data); });
@@ -187,8 +199,9 @@ async function runTests () {
     check('Handles empty response gracefully', emptyResponse.updateTag === undefined && emptyResponse.updatedReleases.length === 0);
 
     section('Real API response shape (pretty-printed, one field per line)');
-    // GitHub's REST API pretty-prints its JSON responses with one field per line, which is
-    // what actually reaches this code in production - unlike the hand-minified fixtures above.
+    // GitHub's REST API pretty-prints its JSON with one field per line when the request carries
+    // an Accept header - which is what actually reaches this code in production, since uiUtil.XHR
+    // goes through XMLHttpRequest and browsers add `Accept: */*` to every request automatically.
     const prettyPrintedPayload = fs.readFileSync(path.join(__dirname, 'fixtures', 'github-releases-sample.json'), 'utf8');
     const prettyRes = await run(prettyPrintedPayload, { appVersion: '3.8.92-E' });
     check('Detects highest version on a realistically pretty-printed response', prettyRes.updateTag === 'v4.0.0-E');
@@ -210,6 +223,31 @@ async function runTests () {
         check('Every matched download URL is well-formed and unquoted', !threw && liveRes.updatedReleases.every(function (url) {
             return /^https:\/\/[^\s"{}[\]]+$/.test(url);
         }));
+
+        // Assert the detected tag against the newest matching release from the parsed payload
+        // itself, so this checks the answer and not just that the output happens to look well-formed
+        if (!threw) {
+            const baseAppPattern = /windows|electron|kiwixwebapp_/i;
+            const liveReleasesJson = JSON.parse(liveReleasesText);
+            const expectedRelease = liveReleasesJson.find(function (release) {
+                return (release.assets || []).some(function (asset) {
+                    return baseAppPattern.test(asset.browser_download_url || '');
+                });
+            });
+            check('Detected tag matches the newest matching release in the parsed payload',
+                !!expectedRelease && liveRes.updateTag === expectedRelease.tag_name);
+        }
+
+        // The Accept-header behaviour documented on fetchLiveReleases is exactly the assumption
+        // this fix rests on: assert the minified and pretty-printed shapes of the same live data
+        // produce identical results, as a direct test of that invariant
+        const liveReleasesTextWithAccept = await fetchLiveReleases(true);
+        if (liveReleasesTextWithAccept !== null) {
+            const liveResWithAccept = await run(liveReleasesTextWithAccept, { appVersion: '0.0.1' });
+            check('Minified (no Accept header) and pretty-printed (Accept: */*) responses agree',
+                liveResWithAccept.updateTag === liveRes.updateTag &&
+                JSON.stringify(liveResWithAccept.updatedReleases) === JSON.stringify(liveRes.updatedReleases));
+        }
     }
 
     section('Consecutive invocation idempotency');

--- a/www/js/lib/updater.js
+++ b/www/js/lib/updater.js
@@ -35,12 +35,11 @@ params.updateServer = {
 };
 
 // A RegExp prototype string to match the current app's releases
-const baseApp = (params.packagedFile && /wikivoyage/.test(params.packagedFile)) ? 'wikivoyage'
-    : (params.packagedFile && /wikimed|mdwiki/.test(params.packagedFile)) ? 'wikimed'
-        : 'windows|electron|kiwixwebapp_'; // Default value
-
-// A RegExp to match download URLs of releases
-const regexpMatchGitHubReleases = RegExp('"browser_download_url[":\\s]+"(https:.*download\\/([^\\/]+).*(?:' + baseApp + ')[^"]+)"', 'ig');
+function getBaseAppPattern () {
+    return (params.packagedFile && /wikivoyage/.test(params.packagedFile)) ? 'wikivoyage'
+        : (params.packagedFile && /wikimed|mdwiki/.test(params.packagedFile)) ? 'wikimed'
+            : 'windows|electron|kiwixwebapp_'; // Default value
+}
 
 /**
  * Get and return the JSON list of releases from the update server's REST API
@@ -74,28 +73,48 @@ function getLatestUpdates (callback) {
     var channelMatchedTag;
     var updateUrl;
     var channelMatchedUpdateUrl;
-    getReleasesObject(function (releases) {
-        var releaseFile;
-        var releaseVersion;
-        var releaseChannel;
-        // Loop through every line in releases
-        var matchedRelease = regexpMatchGitHubReleases.exec(releases);
-        while (matchedRelease != null) {
-            releaseFile = matchedRelease[1];
-            releaseVersion = matchedRelease[2].replace(/^v?([\d.]+).*/, '$1');
-            releaseChannel = matchedRelease[2].replace(/^[v\d.]+/, '');
-            // Compare the releases using a version-type comparison
-            if (releaseVersion.localeCompare(currentRelease, { numeric: true, sensitivity: 'base' }) === 1) {
-                if (!channelMatchedTag && currentReleaseChannel === releaseChannel) {
-                    channelMatchedTag = matchedRelease[2];
-                    channelMatchedUpdateUrl = releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
-                }
-                if (!updateTag) updateTag = matchedRelease[2];
-                if (!updateUrl) updateUrl = releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
-                updatedReleases.push(releaseFile);
-            }
-            matchedRelease = regexpMatchGitHubReleases.exec(releases);
+    getReleasesObject(function (releasesText) {
+        var releases;
+        try {
+            releases = typeof releasesText === 'string' ? JSON.parse(releasesText) : releasesText;
+        } catch (e) {
+            releases = null;
         }
+        if (!Array.isArray(releases)) {
+            callback(undefined, undefined, updatedReleases);
+            return;
+        }
+        var baseAppRegExp = new RegExp(getBaseAppPattern(), 'i');
+        releases.forEach(function (release) {
+            if (!release || !Array.isArray(release.assets)) return;
+            var tag = release.tag_name || '';
+            var releaseVersion = tag.replace(/^v?([\d.]+).*/, '$1');
+            var releaseChannel = tag.replace(/^[v\d.]+/, '');
+            var releaseHtmlUrl = release.html_url || '';
+
+            release.assets.forEach(function (asset) {
+                if (!asset || !asset.browser_download_url) return;
+                var fileName = asset.name || asset.browser_download_url;
+                if (!baseAppRegExp.test(fileName) && !baseAppRegExp.test(asset.browser_download_url)) return;
+
+                var releaseFile = asset.browser_download_url;
+                var assetTag = tag || releaseFile.replace(/^.*\/download\/([^/]+)\/.*$/, '$1');
+                var assetVersion = releaseVersion || assetTag.replace(/^v?([\d.]+).*/, '$1');
+                var assetChannel = releaseChannel || assetTag.replace(/^[v\d.]+/, '');
+                var assetUrl = releaseHtmlUrl || releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
+
+                // Compare the releases using a version-type comparison
+                if (assetVersion.localeCompare(currentRelease, { numeric: true, sensitivity: 'base' }) === 1) {
+                    if (!channelMatchedTag && currentReleaseChannel === assetChannel) {
+                        channelMatchedTag = assetTag;
+                        channelMatchedUpdateUrl = assetUrl;
+                    }
+                    if (!updateTag) updateTag = assetTag;
+                    if (!updateUrl) updateUrl = assetUrl;
+                    updatedReleases.push(releaseFile);
+                }
+            });
+        });
         // We should now have a list of all candidate updates, and candidate channel update
         // Compare the channel-matched update with the update, and if they are the same underlying
         // version number, choose the channel match.

--- a/www/js/lib/updater.js
+++ b/www/js/lib/updater.js
@@ -34,7 +34,13 @@ params.updateServer = {
     releases: 'releases'
 };
 
-// A RegExp prototype string to match the current app's releases
+/**
+ * Builds the RegExp prototype string that matches the current app's releases. Evaluated on each
+ * check rather than once at import time, because params.packagedFile is not necessarily populated
+ * when this module is first loaded.
+ *
+ * @returns {String} An alternation of filename fragments identifying this app's own packages
+ */
 function getBaseAppPattern () {
     return (params.packagedFile && /wikivoyage/.test(params.packagedFile)) ? 'wikivoyage'
         : (params.packagedFile && /wikimed|mdwiki/.test(params.packagedFile)) ? 'wikimed'
@@ -80,10 +86,11 @@ function getLatestUpdates (callback) {
         // Build the RegExp fresh on every call: baseApp depends on params.packagedFile, which
         // may not be set yet when this module is first evaluated, and a module-level /g RegExp
         // would also carry its lastIndex over between calls.
-        // [^"]+ is used in place of a plain wildcard so each capture group stays confined to the
-        // single JSON string value it started in, even if the payload is minified to one line.
+        // [^"]* / [^"]+ is used in place of a plain wildcard so each capture group stays confined to the
+        // single JSON string value it started in, even if the payload is minified to one line: [^"] cannot
+        // match the quote that terminates a JSON string, so a match physically cannot run into the next field.
         var regexpMatchGitHubReleases = RegExp('"browser_download_url[":\\s]+"(https:[^"]*download\\/([^\\/"]+)[^"]*(?:' + getBaseAppPattern() + ')[^"]+)"', 'ig');
-        // Loop through every line in releases
+        // Loop through every matching asset URL
         var matchedRelease = regexpMatchGitHubReleases.exec(releases);
         while (matchedRelease != null) {
             releaseFile = matchedRelease[1];

--- a/www/js/lib/updater.js
+++ b/www/js/lib/updater.js
@@ -73,48 +73,34 @@ function getLatestUpdates (callback) {
     var channelMatchedTag;
     var updateUrl;
     var channelMatchedUpdateUrl;
-    getReleasesObject(function (releasesText) {
-        var releases;
-        try {
-            releases = typeof releasesText === 'string' ? JSON.parse(releasesText) : releasesText;
-        } catch (e) {
-            releases = null;
-        }
-        if (!Array.isArray(releases)) {
-            callback(undefined, undefined, updatedReleases);
-            return;
-        }
-        var baseAppRegExp = new RegExp(getBaseAppPattern(), 'i');
-        releases.forEach(function (release) {
-            if (!release || !Array.isArray(release.assets)) return;
-            var tag = release.tag_name || '';
-            var releaseVersion = tag.replace(/^v?([\d.]+).*/, '$1');
-            var releaseChannel = tag.replace(/^[v\d.]+/, '');
-            var releaseHtmlUrl = release.html_url || '';
-
-            release.assets.forEach(function (asset) {
-                if (!asset || !asset.browser_download_url) return;
-                var fileName = asset.name || asset.browser_download_url;
-                if (!baseAppRegExp.test(fileName) && !baseAppRegExp.test(asset.browser_download_url)) return;
-
-                var releaseFile = asset.browser_download_url;
-                var assetTag = tag || releaseFile.replace(/^.*\/download\/([^/]+)\/.*$/, '$1');
-                var assetVersion = releaseVersion || assetTag.replace(/^v?([\d.]+).*/, '$1');
-                var assetChannel = releaseChannel || assetTag.replace(/^[v\d.]+/, '');
-                var assetUrl = releaseHtmlUrl || releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
-
-                // Compare the releases using a version-type comparison
-                if (assetVersion.localeCompare(currentRelease, { numeric: true, sensitivity: 'base' }) === 1) {
-                    if (!channelMatchedTag && currentReleaseChannel === assetChannel) {
-                        channelMatchedTag = assetTag;
-                        channelMatchedUpdateUrl = assetUrl;
-                    }
-                    if (!updateTag) updateTag = assetTag;
-                    if (!updateUrl) updateUrl = assetUrl;
-                    updatedReleases.push(releaseFile);
+    getReleasesObject(function (releases) {
+        var releaseFile;
+        var releaseVersion;
+        var releaseChannel;
+        // Build the RegExp fresh on every call: baseApp depends on params.packagedFile, which
+        // may not be set yet when this module is first evaluated, and a module-level /g RegExp
+        // would also carry its lastIndex over between calls.
+        // [^"]+ is used in place of a plain wildcard so each capture group stays confined to the
+        // single JSON string value it started in, even if the payload is minified to one line.
+        var regexpMatchGitHubReleases = RegExp('"browser_download_url[":\\s]+"(https:[^"]*download\\/([^\\/"]+)[^"]*(?:' + getBaseAppPattern() + ')[^"]+)"', 'ig');
+        // Loop through every line in releases
+        var matchedRelease = regexpMatchGitHubReleases.exec(releases);
+        while (matchedRelease != null) {
+            releaseFile = matchedRelease[1];
+            releaseVersion = matchedRelease[2].replace(/^v?([\d.]+).*/, '$1');
+            releaseChannel = matchedRelease[2].replace(/^[v\d.]+/, '');
+            // Compare the releases using a version-type comparison
+            if (releaseVersion.localeCompare(currentRelease, { numeric: true, sensitivity: 'base' }) === 1) {
+                if (!channelMatchedTag && currentReleaseChannel === releaseChannel) {
+                    channelMatchedTag = matchedRelease[2];
+                    channelMatchedUpdateUrl = releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
                 }
-            });
-        });
+                if (!updateTag) updateTag = matchedRelease[2];
+                if (!updateUrl) updateUrl = releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
+                updatedReleases.push(releaseFile);
+            }
+            matchedRelease = regexpMatchGitHubReleases.exec(releases);
+        }
         // We should now have a list of all candidate updates, and candidate channel update
         // Compare the channel-matched update with the update, and if they are the same underlying
         // version number, choose the channel match.


### PR DESCRIPTION
Fixes #936

### Problem & Root Cause
In `www/js/lib/updater.js`, `getLatestUpdates()` checks the GitHub Releases API to notify desktop users (Electron, NWJS, UWP) of new releases, using a regex against the raw API text:
```javascript
const regexpMatchGitHubReleases = RegExp('"browser_download_url[":\\s]+"(https:.*download\\/([^\\/]+).*(?:' + baseApp + ')[^"]+)"', 'ig');
```

The greedy `.*` matches `"` as well as any other character, so on a minified/single-line payload it can match across multiple release/asset objects, corrupting the captured URL and skipping releases. The live GitHub API always pretty-prints its JSON one field per line, and `.` doesn't match `\n`, so this couldn't actually happen against production traffic — but it's still a latent bug worth closing, and the module-level `/g` RegExp also carried `lastIndex` state across calls and was built once from a `params.packagedFile` value that may not be set yet.

---

### Solution
Smallest fix that closes the gap, per review discussion:
1. Replace each `.*` in the regex with `[^"]*`/`[^"]+`, so a capture group can't cross the quote that closes the JSON string it started in — confines matching to one field even on minified input.
2. Build the RegExp fresh inside `getLatestUpdates()` (rather than once at module scope), using `getBaseAppPattern()` so it always reflects the current `params.packagedFile`, and avoiding `/g` state leakage between calls.
3. `getBaseAppPattern()` also fixes a real pre-existing bug: the old module-level `baseApp` constant read `params.packagedFile` before it was necessarily set.

No `JSON.parse` rewrite — kept the streaming regex read, both because the risk of a larger change isn't worth it for something that isn't reachable in the field, and because the response is fairly large (mostly a repeated GitHub user object per asset that's never used) and this update check also runs in the UWP build.

---

### Testing
- `test/updater.test.cjs`: minified payloads, channel matching, packaging filters, malformed/empty input, consecutive-call idempotency, a realistic pretty-printed fixture (`test/fixtures/github-releases-sample.json`) matching the real API's shape, and a live test that fetches the actual GitHub releases endpoint and skips gracefully if offline.
- `npm test`: all checks pass.
- `eslint`: 0 errors, 0 warnings on the changed files.
- `npm run build-src`: builds cleanly.

---
Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
