### PR TITLE
Fix fallback to classic file drop when FSA blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Interim release 3.8.92
 
+* FIX: Dropped ZIM files now load in contexts where the browser blocks the File System Access API, by falling back to the legacy file drop
+* FIX: Dropping a folder that the browser will not let the app read no longer voids the folder already picked
 * FIX: Links to articles that are HTML redirect stubs now open the target article correctly in Restricted mode
 * FIX: A navigation inside the article frame can no longer re-run the article setup code and re-inject the same article
 * FIX: Mode now restored to Service Worker on next ZIM load if app has temporarily switched itself to Restricted mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,17 @@ Because this is an offline-first PWA, the app caches its own code, which means t
 * With DevTools open, a hard refresh with Ctrl-Shift-R is often needed to clear the old Service Worker and pick up your new code;
 * Remember to turn "Developer Mode" off again for your final round of testing, so that you are testing the app as users will actually experience it.
 
+### Testing in the browser built into VS Code
+
+The app runs in VS Code's built-in browser, Service Workers and all, so it is a convenient way to look at your changes without leaving the editor. Be aware, though, that this context does not allow the app to read a file or a directory from a File System Access API handle: `getFile()` and directory iteration both reject with `NotAllowedError`. The file and folder pickers will therefore open and let you choose an archive, and only then fail.
+
+To load an archive there, either:
+
+* drag and drop the ZIM file into the app (for a split archive, drop all of its parts together), which falls back to the classic File API; or
+* turn on "Use Private File System" in Configuration, and add an archive to the app's [Origin Private File System](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system), which is unaffected.
+
+Please treat this as a convenience for iterating, not as one of the browsers you test in: it is an unusual context, and a change that works there can still fail in a normal browser. Your testing rounds should be in the browsers listed above.
+
 **Please state in the PR body what testing you have done**: what you ran, in which modes, and on which platforms. There is no required format, but if you do not tell us, we reserve the right not to review the PR until you do.
 
 ## Using AI assistants

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4463,41 +4463,71 @@ function handleFileDrop (packet) {
         params.pickedFolder = '';
         params.storedFile = '';
     }
+    // We have to grab the FileList synchronously, because the DataTransfer object is neutered
+    // once this event handler returns, and we may need it in an asynchronous fallback below
+    var files = packet.dataTransfer.files;
+    // For the same reason, note now whether a folder was dropped: the DataTransfer never contains a
+    // folder's contents, so there is no legacy fallback for a folder we are not allowed to read
+    var droppedFolder = false;
+    if (items && items.length === 1 && typeof items[0].webkitGetAsEntry === 'function') {
+        var droppedEntry = items[0].webkitGetAsEntry();
+        droppedFolder = !!(droppedEntry && droppedEntry.isDirectory);
+    }
     // When dropping multiple files (e.g. a split archive), we cannot use the File System Access API
     if (items && items.length === 1 && items[0].kind === 'file' && typeof items[0].getAsFileSystemHandle !== 'undefined') {
         items[0].getAsFileSystemHandle().then(function (handle) {
             if (handle.kind === 'file') {
-                processNativeFileHandle(handle);
+                return processNativeFileHandle(handle);
             } else if (handle.kind === 'directory') {
-                processNativeDirHandle(handle);
+                // Check we can actually read the directory before we delegate, because processNativeDirHandle
+                // reports its own errors to the user and so cannot signal to us that we should fall back
+                return handle.entries().next().then(function () {
+                    return processNativeDirHandle(handle);
+                });
             }
+        }).catch(function (err) {
+            // Some contexts (e.g. the Electron file:// window) hand us a file system handle but then refuse
+            // to read it, so fall back to the legacy file drop, which does not need the File System Access API
+            console.warn('Unable to process the dropped file system handle', err);
+            if (droppedFolder) {
+                // Falling back would void the folder the user already picked and then fail anyway
+                uiUtil.systemAlert('<p>This browser will not allow the app to read a dropped folder in the current context.</p>' +
+                    '<p>Please use the folder picker in Configuration instead, or drop the ZIM file or files rather than the folder.</p>', 'Cannot read dropped folder');
+                return;
+            }
+            console.warn('Falling back to the legacy file drop');
+            handleLegacyFileDrop(files);
         });
     } else {
-        var files = packet.dataTransfer.files;
-        // Try to store the dragged files (in at least IE11, this is read only, so we have to wrap in try ... catch)
-        try {
-            archiveFilesLegacy.files = files;
-        } catch (err) {
-            console.warn('Unable to store dropped files in legacy file picker, so selecting first file if not split', err);
-            if (!/\.zim\w\w$/i.test(files[0].name) && files.length > 1) {
-                uiUtil.systemAlert('You have dropped multiple files, but in older browsers only the first can be loaded. Please drop only one file at a time in this browser, or use the file picker to pick more.');
-                files = [files[0]];
-            }
-        }
-        document.getElementById('openLocalFiles').style.display = 'none';
-        document.getElementById('rescanStorage').style.display = 'block';
-        document.getElementById('usage').style.display = 'none';
-        // We have to void the previous picked folder, because dragged files don't have a folder
-        // This also prevents a file-not-found alert to the user when picking a new directory
-        params.pickedFolder = null;
-        settingsStore.setItem('pickedFolder', '', Infinity);
-        params.pickedFile = null;
-        params.storedFile = null;
-        params.rescan = false;
-        setLocalArchiveFromFileList(files);
-        // Delete any previous file system handle (as otherwise, it will get inadvertienly reloaded)
-        cache.idxDB('delete', 'pickedFSHandle', function () {});
+        handleLegacyFileDrop(files);
     }
+}
+
+// Loads dropped files without using the File System Access API (also used as a fallback if that API is blocked)
+function handleLegacyFileDrop (files) {
+    // Try to store the dragged files (in at least IE11, this is read only, so we have to wrap in try ... catch)
+    try {
+        archiveFilesLegacy.files = files;
+    } catch (err) {
+        console.warn('Unable to store dropped files in legacy file picker, so selecting first file if not split', err);
+        if (!/\.zim\w\w$/i.test(files[0].name) && files.length > 1) {
+            uiUtil.systemAlert('You have dropped multiple files, but in older browsers only the first can be loaded. Please drop only one file at a time in this browser, or use the file picker to pick more.');
+            files = [files[0]];
+        }
+    }
+    document.getElementById('openLocalFiles').style.display = 'none';
+    document.getElementById('rescanStorage').style.display = 'block';
+    document.getElementById('usage').style.display = 'none';
+    // We have to void the previous picked folder, because dragged files don't have a folder
+    // This also prevents a file-not-found alert to the user when picking a new directory
+    params.pickedFolder = null;
+    settingsStore.setItem('pickedFolder', '', Infinity);
+    params.pickedFile = null;
+    params.storedFile = null;
+    params.rescan = false;
+    setLocalArchiveFromFileList(files);
+    // Delete any previous file system handle (as otherwise, it will get inadvertienly reloaded)
+    cache.idxDB('delete', 'pickedFSHandle', function () {});
 }
 
 function pickFileUWP () { // Support UWP FilePicker [kiwix-js-pwa #3]

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4486,7 +4486,7 @@ function handleFileDrop (packet) {
                 });
             }
         }).catch(function (err) {
-            // Some contexts (e.g. the Electron file:// window) hand us a file system handle but then refuse
+            // Some contexts (e.g. a file:// window in the VS Code Browser) hand us a file system handle but then refuse
             // to read it, so fall back to the legacy file drop, which does not need the File System Access API
             console.warn('Unable to process the dropped file system handle', err);
             if (droppedFolder) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4492,7 +4492,8 @@ function handleFileDrop (packet) {
             if (droppedFolder) {
                 // Falling back would void the folder the user already picked and then fail anyway
                 uiUtil.systemAlert('<p>This browser will not allow the app to read a dropped folder in the current context.</p>' +
-                    '<p>Please use the folder picker in Configuration instead, or drop the ZIM file or files rather than the folder.</p>', 'Cannot read dropped folder');
+                    '<p>Please drop the ZIM file itself instead of the folder, or, if the archive is split, drop all of its parts together.</p>',
+                'Cannot read dropped folder');
                 return;
             }
             console.warn('Falling back to the legacy file drop');

--- a/www/js/lib/cache.js
+++ b/www/js/lib/cache.js
@@ -911,6 +911,9 @@ function iterateAsyncDirEntries (entries, archives, noFilter) {
                 if (window.fs && !params.pickedFolder.path) {
                     entry.getFile().then(function (file) {
                         params.pickedFolder.path = file.path;
+                    }).catch(function (err) {
+                        // We only wanted the path, so log and carry on rather than leaving an unhandled rejection
+                        console.warn('Unable to get the path of ' + entry.name, err);
                     });
                 }
             }


### PR DESCRIPTION
Fixes #940.

This allows the FSA File Handling to fall back to the older drag-and-drop API.

NB it doesn't fix directory dropping which was never properly handled, and so that would be a new feature / PR.

Need to test that this does not affect the OPFS.